### PR TITLE
test(ci): add public surface planning guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,6 @@ jobs:
 
       - name: Test
         run: cargo test
+
+      - name: Public surface audit
+        run: pwsh -NoProfile -File scripts/audit-public-surface.ps1

--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ GitHub Actions runs:
 
 - `cargo fmt --check`
 - `cargo check`
+- `cargo test`
+- `pwsh -NoProfile -File scripts/audit-public-surface.ps1`
 
 The `main` branch is protected and requires:
 

--- a/scripts/audit-public-surface.ps1
+++ b/scripts/audit-public-surface.ps1
@@ -1,0 +1,62 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+function Get-TrackedFiles {
+    $output = git ls-files
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Failed to list tracked files.'
+    }
+
+    return @($output | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+}
+
+function Test-Tracked {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$TrackedFiles,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    return ($TrackedFiles -contains $Path)
+}
+
+$trackedFiles = Get-TrackedFiles
+$failures = New-Object System.Collections.Generic.List[string]
+
+$requiredTracked = @(
+    'tasks/README.md',
+    'tasks/backlog.example.yaml',
+    'tasks/roadmap-title-ja.example.psd1',
+    'tasks/ROADMAP.example.md',
+    'scripts/planning-paths.ps1',
+    'scripts/sync-roadmap.ps1'
+)
+
+$forbiddenTracked = @(
+    'tasks/backlog.yaml',
+    'tasks/roadmap-title-ja.psd1',
+    'docs/project/ROADMAP.md'
+)
+
+foreach ($path in $requiredTracked) {
+    if (-not (Test-Tracked -TrackedFiles $trackedFiles -Path $path)) {
+        $failures.Add("missing tracked file: $path") | Out-Null
+    }
+}
+
+foreach ($path in $forbiddenTracked) {
+    if (Test-Tracked -TrackedFiles $trackedFiles -Path $path) {
+        $failures.Add("forbidden tracked file: $path") | Out-Null
+    }
+}
+
+if ($failures.Count -gt 0) {
+    Write-Error ("public surface audit failed:`n- " + ($failures -join "`n- "))
+    exit 1
+}
+
+Write-Output 'public surface audit passed'

--- a/tests/public_surface.rs
+++ b/tests/public_surface.rs
@@ -1,0 +1,57 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+use anyhow::{Context, Result};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn powershell() -> &'static str {
+    "pwsh"
+}
+
+#[test]
+fn public_surface_audit_script_succeeds_for_tracked_repo_state() -> Result<()> {
+    let script_path = repo_root().join("scripts").join("audit-public-surface.ps1");
+    let output = Command::new(powershell())
+        .arg("-NoProfile")
+        .arg("-File")
+        .arg(&script_path)
+        .current_dir(repo_root())
+        .output()
+        .with_context(|| format!("failed to run {}", script_path.display()))?;
+
+    assert!(
+        output.status.success(),
+        "audit-public-surface failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    Ok(())
+}
+
+#[test]
+fn live_planning_files_stay_untracked_and_examples_stay_tracked() -> Result<()> {
+    let output = Command::new("git")
+        .args(["ls-files"])
+        .current_dir(repo_root())
+        .output()
+        .context("failed to list tracked files")?;
+
+    assert!(
+        output.status.success(),
+        "git ls-files failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let tracked = String::from_utf8(output.stdout)?;
+    assert!(tracked.contains("tasks/backlog.example.yaml"));
+    assert!(tracked.contains("tasks/roadmap-title-ja.example.psd1"));
+    assert!(tracked.contains("tasks/ROADMAP.example.md"));
+    assert!(!tracked.contains("tasks/backlog.yaml"));
+    assert!(!tracked.contains("tasks/roadmap-title-ja.psd1"));
+    assert!(!tracked.contains("docs/project/ROADMAP.md"));
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a public surface audit script for planning files
- enforce the audit in CI alongside cargo test
- add coverage for tracked examples and forbidden live planning files

## Validation
- cargo fmt --check
- cargo test
- cargo check
- pwsh -NoProfile -File scripts/audit-public-surface.ps1