### PR TITLE
feat: add one-command planning setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ cargo run -- service uninstall
 pwsh -NoProfile -File scripts/sync-roadmap.ps1
 ```
 
+8. Initialize the external planning workspace in one step:
+
+```powershell
+pwsh -NoProfile -File scripts/setup-planning.ps1
+```
+
 ## Configuration
 
 The main local config file is [`bridge.toml`](bridge.toml).
@@ -169,6 +175,7 @@ The `main` branch is protected and requires:
 Maintainer planning files live outside the repository, following the same pattern as `winsmux`.
 
 - `scripts/sync-roadmap.ps1` reads `backlog.yaml` and writes `ROADMAP.md`
+- `scripts/setup-planning.ps1` creates the external planning root, writes the marker, copies examples, and runs the first sync
 - `scripts/planning-paths.ps1` resolves the planning root from `CODEX_CHANNELS_PLANNING_ROOT` or `%LOCALAPPDATA%\\codex-channels\\planning-root.txt`
 - tracked files under `tasks/` are example-only bootstrap files
 

--- a/scripts/audit-public-surface.ps1
+++ b/scripts/audit-public-surface.ps1
@@ -24,7 +24,20 @@ function Test-Tracked {
     return ($TrackedFiles -contains $Path)
 }
 
+function Test-RepoFileExists {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RepoRoot,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    return (Test-Path -LiteralPath (Join-Path $RepoRoot $Path))
+}
+
 $trackedFiles = Get-TrackedFiles
+$repoRoot = (Resolve-Path '.').Path
 $failures = New-Object System.Collections.Generic.List[string]
 
 $requiredTracked = @(
@@ -33,6 +46,7 @@ $requiredTracked = @(
     'tasks/roadmap-title-ja.example.psd1',
     'tasks/ROADMAP.example.md',
     'scripts/planning-paths.ps1',
+    'scripts/setup-planning.ps1',
     'scripts/sync-roadmap.ps1'
 )
 
@@ -43,8 +57,8 @@ $forbiddenTracked = @(
 )
 
 foreach ($path in $requiredTracked) {
-    if (-not (Test-Tracked -TrackedFiles $trackedFiles -Path $path)) {
-        $failures.Add("missing tracked file: $path") | Out-Null
+    if (-not (Test-RepoFileExists -RepoRoot $repoRoot -Path $path)) {
+        $failures.Add("missing required file: $path") | Out-Null
     }
 }
 

--- a/scripts/planning-paths.ps1
+++ b/scripts/planning-paths.ps1
@@ -2,6 +2,11 @@
 param()
 
 function Get-CodexChannelsPlanningRootMarkerPath {
+    $explicitMarkerPath = [Environment]::GetEnvironmentVariable('CODEX_CHANNELS_PLANNING_ROOT_MARKER')
+    if (-not [string]::IsNullOrWhiteSpace($explicitMarkerPath)) {
+        return $explicitMarkerPath
+    }
+
     $localAppData = if ($env:LOCALAPPDATA) { $env:LOCALAPPDATA } else { [Environment]::GetFolderPath('LocalApplicationData') }
     return Join-Path $localAppData 'codex-channels\planning-root.txt'
 }

--- a/scripts/setup-planning.ps1
+++ b/scripts/setup-planning.ps1
@@ -1,0 +1,58 @@
+[CmdletBinding()]
+param(
+    [string]$PlanningRoot = '',
+    [string]$MarkerPath = ''
+)
+
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'planning-paths.ps1')
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+
+if ([string]::IsNullOrWhiteSpace($PlanningRoot)) {
+    $PlanningRoot = Get-CodexChannelsPlanningRoot
+}
+
+if ([string]::IsNullOrWhiteSpace($MarkerPath)) {
+    $MarkerPath = Get-CodexChannelsPlanningRootMarkerPath
+}
+
+$resolvedPlanningRoot = if ([System.IO.Path]::IsPathRooted($PlanningRoot)) { $PlanningRoot } else { Join-Path (Get-Location).Path $PlanningRoot }
+$resolvedMarkerPath = if ([System.IO.Path]::IsPathRooted($MarkerPath)) { $MarkerPath } else { Join-Path (Get-Location).Path $MarkerPath }
+
+New-Item -ItemType Directory -Force -Path $resolvedPlanningRoot | Out-Null
+
+$markerDirectory = Split-Path -Parent $resolvedMarkerPath
+if (-not [string]::IsNullOrWhiteSpace($markerDirectory)) {
+    New-Item -ItemType Directory -Force -Path $markerDirectory | Out-Null
+}
+
+[System.IO.File]::WriteAllText($resolvedMarkerPath, $resolvedPlanningRoot, $utf8NoBom)
+
+$examplePairs = @(
+    @{
+        Source = Join-Path $repoRoot 'tasks/backlog.example.yaml'
+        Target = Join-Path $resolvedPlanningRoot 'backlog.yaml'
+    },
+    @{
+        Source = Join-Path $repoRoot 'tasks/roadmap-title-ja.example.psd1'
+        Target = Join-Path $resolvedPlanningRoot 'roadmap-title-ja.psd1'
+    }
+)
+
+foreach ($pair in $examplePairs) {
+    if (-not (Test-Path -LiteralPath $pair.Target)) {
+        Copy-Item -LiteralPath $pair.Source -Destination $pair.Target
+    }
+}
+
+$syncRoadmapScript = Join-Path $repoRoot 'scripts/sync-roadmap.ps1'
+& $syncRoadmapScript `
+    -BacklogPath (Join-Path $resolvedPlanningRoot 'backlog.yaml') `
+    -RoadmapPath (Join-Path $resolvedPlanningRoot 'ROADMAP.md') `
+    -RoadmapTitleJaPath (Join-Path $resolvedPlanningRoot 'roadmap-title-ja.psd1')
+
+Write-Output ("Planning root: {0}" -f $resolvedPlanningRoot)
+Write-Output ("Marker path: {0}" -f $resolvedMarkerPath)

--- a/tests/roadmap_sync.rs
+++ b/tests/roadmap_sync.rs
@@ -135,3 +135,80 @@ fn planning_paths_prefers_env_override() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn setup_planning_creates_live_files_and_marker() -> Result<()> {
+    let temp = TempDir::new()?;
+    let planning_root = temp.path().join("planning-root");
+    let marker_path = temp.path().join("planning-root.txt");
+
+    let output = Command::new(powershell())
+        .arg("-NoProfile")
+        .arg("-File")
+        .arg(repo_root().join("scripts").join("setup-planning.ps1"))
+        .arg("-PlanningRoot")
+        .arg(&planning_root)
+        .arg("-MarkerPath")
+        .arg(&marker_path)
+        .output()
+        .context("failed to run setup-planning.ps1")?;
+
+    assert!(
+        output.status.success(),
+        "setup-planning failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert_eq!(
+        fs::read_to_string(&marker_path)?,
+        planning_root.display().to_string()
+    );
+    assert!(planning_root.join("backlog.yaml").exists());
+    assert!(planning_root.join("roadmap-title-ja.psd1").exists());
+    assert!(planning_root.join("ROADMAP.md").exists());
+
+    let roadmap = fs::read_to_string(planning_root.join("ROADMAP.md"))?;
+    assert!(roadmap.contains("# ロードマップ"));
+    assert!(roadmap.contains("ブリッジ基盤を作成"));
+
+    Ok(())
+}
+
+#[test]
+fn setup_planning_preserves_existing_live_files() -> Result<()> {
+    let temp = TempDir::new()?;
+    let planning_root = temp.path().join("planning-root");
+    let marker_path = temp.path().join("planning-root.txt");
+    fs::create_dir_all(&planning_root)?;
+
+    let existing_backlog = planning_root.join("backlog.yaml");
+    write_file(
+        &existing_backlog,
+        "# === v9.9.9: Custom ===\n- id: TASK-999\n    title: Keep custom backlog\n    status: active\n    priority: P0\n    target_version: v9.9.9\n    repo: codex-channels\n",
+    )?;
+
+    let output = Command::new(powershell())
+        .arg("-NoProfile")
+        .arg("-File")
+        .arg(repo_root().join("scripts").join("setup-planning.ps1"))
+        .arg("-PlanningRoot")
+        .arg(&planning_root)
+        .arg("-MarkerPath")
+        .arg(&marker_path)
+        .output()
+        .context("failed to run setup-planning.ps1")?;
+
+    assert!(
+        output.status.success(),
+        "setup-planning failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let backlog = fs::read_to_string(&existing_backlog)?;
+    assert!(backlog.contains("Keep custom backlog"));
+
+    let roadmap = fs::read_to_string(planning_root.join("ROADMAP.md"))?;
+    assert!(roadmap.contains("Keep custom backlog"));
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add scripts/setup-planning.ps1 to create the external planning root, marker, and first roadmap in one step
- extend planning path resolution and public surface audit for the new setup flow
- add integration tests that cover setup creation and preservation of existing live files

## Testing
- cargo fmt --check
- cargo test
- cargo check
- pwsh -NoProfile -File scripts/audit-public-surface.ps1