### PR TITLE
fix: keep planning marker unchanged on sync failure

### DIFF
--- a/scripts/setup-planning.ps1
+++ b/scripts/setup-planning.ps1
@@ -24,13 +24,6 @@ $resolvedMarkerPath = if ([System.IO.Path]::IsPathRooted($MarkerPath)) { $Marker
 
 New-Item -ItemType Directory -Force -Path $resolvedPlanningRoot | Out-Null
 
-$markerDirectory = Split-Path -Parent $resolvedMarkerPath
-if (-not [string]::IsNullOrWhiteSpace($markerDirectory)) {
-    New-Item -ItemType Directory -Force -Path $markerDirectory | Out-Null
-}
-
-[System.IO.File]::WriteAllText($resolvedMarkerPath, $resolvedPlanningRoot, $utf8NoBom)
-
 $examplePairs = @(
     @{
         Source = Join-Path $repoRoot 'tasks/backlog.example.yaml'
@@ -53,6 +46,13 @@ $syncRoadmapScript = Join-Path $repoRoot 'scripts/sync-roadmap.ps1'
     -BacklogPath (Join-Path $resolvedPlanningRoot 'backlog.yaml') `
     -RoadmapPath (Join-Path $resolvedPlanningRoot 'ROADMAP.md') `
     -RoadmapTitleJaPath (Join-Path $resolvedPlanningRoot 'roadmap-title-ja.psd1')
+
+$markerDirectory = Split-Path -Parent $resolvedMarkerPath
+if (-not [string]::IsNullOrWhiteSpace($markerDirectory)) {
+    New-Item -ItemType Directory -Force -Path $markerDirectory | Out-Null
+}
+
+[System.IO.File]::WriteAllText($resolvedMarkerPath, $resolvedPlanningRoot, $utf8NoBom)
 
 Write-Output ("Planning root: {0}" -f $resolvedPlanningRoot)
 Write-Output ("Marker path: {0}" -f $resolvedMarkerPath)

--- a/tests/roadmap_sync.rs
+++ b/tests/roadmap_sync.rs
@@ -212,3 +212,40 @@ fn setup_planning_preserves_existing_live_files() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn setup_planning_does_not_update_marker_when_sync_fails() -> Result<()> {
+    let temp = TempDir::new()?;
+    let planning_root = temp.path().join("planning-root");
+    let marker_path = temp.path().join("planning-root.txt");
+    let previous_root = temp.path().join("previous-root");
+    fs::create_dir_all(&planning_root)?;
+    fs::write(&marker_path, previous_root.display().to_string())?;
+    write_file(
+        &planning_root.join("roadmap-title-ja.psd1"),
+        "@{\nVersionTitles =\n",
+    )?;
+
+    let output = Command::new(powershell())
+        .arg("-NoProfile")
+        .arg("-File")
+        .arg(repo_root().join("scripts").join("setup-planning.ps1"))
+        .arg("-PlanningRoot")
+        .arg(&planning_root)
+        .arg("-MarkerPath")
+        .arg(&marker_path)
+        .output()
+        .context("failed to run setup-planning.ps1")?;
+
+    assert!(
+        !output.status.success(),
+        "setup-planning unexpectedly succeeded: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(&marker_path)?,
+        previous_root.display().to_string()
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- update setup-planning.ps1 to write the marker only after sync-roadmap.ps1 succeeds
- add an integration test that proves failed setup keeps the previous marker value
- keep the existing success-path tests unchanged

## Testing
- cargo fmt --check
- cargo test --test roadmap_sync
- cargo test
- cargo check
- pwsh -NoProfile -File scripts/audit-public-surface.ps1