### PR TITLE
feat: validate planning inputs before roadmap sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,8 @@ jobs:
       - name: Test
         run: cargo test
 
+      - name: Planning validation
+        run: pwsh -NoProfile -File scripts/validate-planning.ps1
+
       - name: Public surface audit
         run: pwsh -NoProfile -File scripts/audit-public-surface.ps1

--- a/README.md
+++ b/README.md
@@ -85,7 +85,13 @@ cargo run -- service uninstall
 pwsh -NoProfile -File scripts/sync-roadmap.ps1
 ```
 
-8. Initialize the external planning workspace in one step:
+8. Validate planning inputs before syncing:
+
+```powershell
+pwsh -NoProfile -File scripts/validate-planning.ps1
+```
+
+9. Initialize the external planning workspace in one step:
 
 ```powershell
 pwsh -NoProfile -File scripts/setup-planning.ps1
@@ -175,6 +181,7 @@ The `main` branch is protected and requires:
 Maintainer planning files live outside the repository, following the same pattern as `winsmux`.
 
 - `scripts/sync-roadmap.ps1` reads `backlog.yaml` and writes `ROADMAP.md`
+- `scripts/validate-planning.ps1` checks `backlog.yaml` and `roadmap-title-ja.psd1` before sync
 - `scripts/setup-planning.ps1` creates the external planning root, writes the marker, copies examples, and runs the first sync
 - `scripts/planning-paths.ps1` resolves the planning root from `CODEX_CHANNELS_PLANNING_ROOT` or `%LOCALAPPDATA%\\codex-channels\\planning-root.txt`
 - tracked files under `tasks/` are example-only bootstrap files

--- a/scripts/audit-public-surface.ps1
+++ b/scripts/audit-public-surface.ps1
@@ -24,20 +24,7 @@ function Test-Tracked {
     return ($TrackedFiles -contains $Path)
 }
 
-function Test-RepoFileExists {
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$RepoRoot,
-
-        [Parameter(Mandatory = $true)]
-        [string]$Path
-    )
-
-    return (Test-Path -LiteralPath (Join-Path $RepoRoot $Path))
-}
-
 $trackedFiles = Get-TrackedFiles
-$repoRoot = (Resolve-Path '.').Path
 $failures = New-Object System.Collections.Generic.List[string]
 
 $requiredTracked = @(
@@ -48,6 +35,7 @@ $requiredTracked = @(
     'scripts/planning-paths.ps1',
     'scripts/setup-planning.ps1',
     'scripts/sync-roadmap.ps1'
+    'scripts/validate-planning.ps1'
 )
 
 $forbiddenTracked = @(
@@ -57,8 +45,8 @@ $forbiddenTracked = @(
 )
 
 foreach ($path in $requiredTracked) {
-    if (-not (Test-RepoFileExists -RepoRoot $repoRoot -Path $path)) {
-        $failures.Add("missing required file: $path") | Out-Null
+    if (-not (Test-Tracked -TrackedFiles $trackedFiles -Path $path)) {
+        $failures.Add("missing tracked file: $path") | Out-Null
     }
 }
 

--- a/scripts/setup-planning.ps1
+++ b/scripts/setup-planning.ps1
@@ -24,28 +24,32 @@ $resolvedMarkerPath = if ([System.IO.Path]::IsPathRooted($MarkerPath)) { $Marker
 
 New-Item -ItemType Directory -Force -Path $resolvedPlanningRoot | Out-Null
 
-$examplePairs = @(
-    @{
-        Source = Join-Path $repoRoot 'tasks/backlog.example.yaml'
-        Target = Join-Path $resolvedPlanningRoot 'backlog.yaml'
-    },
-    @{
-        Source = Join-Path $repoRoot 'tasks/roadmap-title-ja.example.psd1'
-        Target = Join-Path $resolvedPlanningRoot 'roadmap-title-ja.psd1'
-    }
-)
+$backlogTarget = Join-Path $resolvedPlanningRoot 'backlog.yaml'
+$titleTarget = Join-Path $resolvedPlanningRoot 'roadmap-title-ja.psd1'
+$backlogAlreadyExists = Test-Path -LiteralPath $backlogTarget
 
-foreach ($pair in $examplePairs) {
-    if (-not (Test-Path -LiteralPath $pair.Target)) {
-        Copy-Item -LiteralPath $pair.Source -Destination $pair.Target
+if (-not $backlogAlreadyExists) {
+    Copy-Item -LiteralPath (Join-Path $repoRoot 'tasks/backlog.example.yaml') -Destination $backlogTarget
+}
+
+if (-not (Test-Path -LiteralPath $titleTarget)) {
+    if ($backlogAlreadyExists) {
+        [System.IO.File]::WriteAllText($titleTarget, "@{`n    VersionTitles = @{} `n    TaskTitles = @{} `n}`n", $utf8NoBom)
+    } else {
+        Copy-Item -LiteralPath (Join-Path $repoRoot 'tasks/roadmap-title-ja.example.psd1') -Destination $titleTarget
     }
 }
 
+$validatePlanningScript = Join-Path $repoRoot 'scripts/validate-planning.ps1'
+& $validatePlanningScript `
+    -BacklogPath $backlogTarget `
+    -RoadmapTitleJaPath $titleTarget
+
 $syncRoadmapScript = Join-Path $repoRoot 'scripts/sync-roadmap.ps1'
 & $syncRoadmapScript `
-    -BacklogPath (Join-Path $resolvedPlanningRoot 'backlog.yaml') `
+    -BacklogPath $backlogTarget `
     -RoadmapPath (Join-Path $resolvedPlanningRoot 'ROADMAP.md') `
-    -RoadmapTitleJaPath (Join-Path $resolvedPlanningRoot 'roadmap-title-ja.psd1')
+    -RoadmapTitleJaPath $titleTarget
 
 $markerDirectory = Split-Path -Parent $resolvedMarkerPath
 if (-not [string]::IsNullOrWhiteSpace($markerDirectory)) {

--- a/scripts/validate-planning.ps1
+++ b/scripts/validate-planning.ps1
@@ -1,0 +1,200 @@
+[CmdletBinding()]
+param(
+    [string]$BacklogPath = '',
+    [string]$RoadmapTitleJaPath = ''
+)
+
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'planning-paths.ps1')
+
+function Resolve-WorkspacePath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if ([System.IO.Path]::IsPathRooted($Path)) {
+        return $Path
+    }
+
+    return Join-Path (Get-Location).Path $Path
+}
+
+function Get-TaskBlocks {
+    param([Parameter(Mandatory = $true)][string]$Content)
+
+    $normalized = $Content -replace "`r`n", "`n"
+    $lines = $normalized -split "`n"
+    $blocks = New-Object System.Collections.Generic.List[object]
+    $current = $null
+
+    foreach ($line in $lines) {
+        if ($line -match '^[ \t]*-[ \t]+id:[ \t]*(?<id>\S+)[ \t]*$') {
+            if ($null -ne $current -and $current.Count -gt 0) {
+                $blocks.Add([pscustomobject]@{ Lines = @($current.ToArray()) })
+            }
+
+            $current = New-Object System.Collections.Generic.List[string]
+            $current.Add($line)
+            continue
+        }
+
+        if ($null -ne $current) {
+            $current.Add($line)
+        }
+    }
+
+    if ($null -ne $current -and $current.Count -gt 0) {
+        $blocks.Add([pscustomobject]@{ Lines = @($current.ToArray()) })
+    }
+
+    return $blocks
+}
+
+function Get-TaskValues {
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [AllowEmptyCollection()]
+        [string[]]$Lines
+    )
+
+    if ($Lines[0] -notmatch '^[ \t]*-[ \t]+id:[ \t]*(?<id>\S+)[ \t]*$') {
+        return $null
+    }
+
+    $values = @{
+        id = $Matches['id']
+    }
+
+    for ($index = 1; $index -lt $Lines.Count; $index++) {
+        $line = $Lines[$index]
+        if ($line -match '^[ \t]{4}(?<key>[a-z_]+):[ \t]*(?<value>.*)$') {
+            $values[$Matches['key']] = $Matches['value'].Trim()
+        }
+    }
+
+    return $values
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$localBacklogPath = Join-Path $repoRoot 'tasks/backlog.example.yaml'
+$localTitlePath = Join-Path $repoRoot 'tasks/roadmap-title-ja.example.psd1'
+$planningRoot = Get-CodexChannelsPlanningRoot
+$externalBacklogPath = Join-Path $planningRoot 'backlog.yaml'
+$externalTitlePath = Join-Path $planningRoot 'roadmap-title-ja.psd1'
+
+if ([string]::IsNullOrWhiteSpace($BacklogPath) -and [string]::IsNullOrWhiteSpace($RoadmapTitleJaPath)) {
+    if ((Test-Path -LiteralPath $externalBacklogPath) -or (Test-Path -LiteralPath $externalTitlePath)) {
+        $BacklogPath = $externalBacklogPath
+        $RoadmapTitleJaPath = $externalTitlePath
+    } else {
+        $BacklogPath = $localBacklogPath
+        $RoadmapTitleJaPath = $localTitlePath
+    }
+} elseif ([string]::IsNullOrWhiteSpace($BacklogPath)) {
+    $resolvedRoadmapTitleJaPath = Resolve-WorkspacePath -Path $RoadmapTitleJaPath
+    $BacklogPath = Join-Path (Split-Path -Parent $resolvedRoadmapTitleJaPath) 'backlog.yaml'
+} elseif ([string]::IsNullOrWhiteSpace($RoadmapTitleJaPath)) {
+    $resolvedBacklogPath = Resolve-WorkspacePath -Path $BacklogPath
+    $RoadmapTitleJaPath = Join-Path (Split-Path -Parent $resolvedBacklogPath) 'roadmap-title-ja.psd1'
+}
+
+$resolvedBacklogPath = Resolve-WorkspacePath -Path $BacklogPath
+$resolvedRoadmapTitleJaPath = Resolve-WorkspacePath -Path $RoadmapTitleJaPath
+$failures = New-Object System.Collections.Generic.List[string]
+
+if (-not (Test-Path -LiteralPath $resolvedBacklogPath)) {
+    $failures.Add("backlog.yaml not found: $resolvedBacklogPath") | Out-Null
+} else {
+    $backlogContent = Get-Content -LiteralPath $resolvedBacklogPath -Raw
+    $taskBlocks = @(Get-TaskBlocks -Content $backlogContent)
+    if ($taskBlocks.Count -eq 0) {
+        $failures.Add('backlog.yaml does not contain any task blocks') | Out-Null
+    }
+
+    $taskIds = New-Object System.Collections.Generic.HashSet[string]
+    $versions = New-Object System.Collections.Generic.HashSet[string]
+    $allowedStatuses = @('done', 'review', 'in-progress', 'in_progress', 'doing', 'active', 'cancelled', 'backlog')
+    $allowedPriorities = @('P0', 'P1', 'P2', 'P3')
+    $requiredKeys = @('title', 'status', 'priority', 'target_version', 'repo')
+
+    foreach ($taskBlock in $taskBlocks) {
+        $values = Get-TaskValues -Lines @($taskBlock.Lines)
+        if ($null -eq $values) {
+            $failures.Add('backlog.yaml contains a task block without a valid id line') | Out-Null
+            continue
+        }
+
+        $taskId = [string]$values['id']
+        if ($taskId -notmatch '^TASK-\d+$') {
+            $failures.Add("task id '$taskId' must match TASK-<number>") | Out-Null
+        } elseif (-not $taskIds.Add($taskId)) {
+            $failures.Add("task id '$taskId' is duplicated") | Out-Null
+        }
+
+        foreach ($requiredKey in $requiredKeys) {
+            if (-not $values.ContainsKey($requiredKey) -or [string]::IsNullOrWhiteSpace([string]$values[$requiredKey])) {
+                $failures.Add("task '$taskId' is missing required field '$requiredKey'") | Out-Null
+            }
+        }
+
+        if ($values.ContainsKey('priority') -and ($allowedPriorities -notcontains [string]$values['priority'])) {
+            $failures.Add("task '$taskId' has invalid priority '$($values['priority'])'") | Out-Null
+        }
+
+        if ($values.ContainsKey('status') -and ($allowedStatuses -notcontains [string]$values['status'])) {
+            $failures.Add("task '$taskId' has invalid status '$($values['status'])'") | Out-Null
+        }
+
+        if ($values.ContainsKey('target_version')) {
+            $targetVersion = [string]$values['target_version']
+            if ($targetVersion -notmatch '^v\d+\.\d+\.\d+$') {
+                $failures.Add("task '$taskId' has invalid target_version '$targetVersion'") | Out-Null
+            } else {
+                [void]$versions.Add($targetVersion)
+            }
+        }
+    }
+}
+
+if (-not (Test-Path -LiteralPath $resolvedRoadmapTitleJaPath)) {
+    $failures.Add("roadmap-title-ja.psd1 not found: $resolvedRoadmapTitleJaPath") | Out-Null
+} else {
+    try {
+        $data = Import-PowerShellDataFile -LiteralPath $resolvedRoadmapTitleJaPath
+    } catch {
+        $failures.Add("roadmap-title-ja.psd1 could not be parsed: $resolvedRoadmapTitleJaPath") | Out-Null
+        $data = $null
+    }
+
+    if ($null -ne $data) {
+        $versionTitles = if ($null -ne $data.VersionTitles) { $data.VersionTitles } else { @{} }
+        $taskTitles = if ($null -ne $data.TaskTitles) { $data.TaskTitles } else { @{} }
+
+        if ($versionTitles -isnot [System.Collections.IDictionary]) {
+            $failures.Add('roadmap-title-ja.psd1 VersionTitles must be a hashtable') | Out-Null
+        } else {
+            foreach ($entry in $versionTitles.GetEnumerator()) {
+                if ([string]::IsNullOrWhiteSpace([string]$entry.Value)) {
+                    $failures.Add("VersionTitles entry '$($entry.Key)' must not be empty") | Out-Null
+                }
+            }
+        }
+
+        if ($taskTitles -isnot [System.Collections.IDictionary]) {
+            $failures.Add('roadmap-title-ja.psd1 TaskTitles must be a hashtable') | Out-Null
+        } else {
+            foreach ($entry in $taskTitles.GetEnumerator()) {
+                if ([string]::IsNullOrWhiteSpace([string]$entry.Value)) {
+                    $failures.Add("TaskTitles entry '$($entry.Key)' must not be empty") | Out-Null
+                }
+            }
+        }
+    }
+}
+
+if ($failures.Count -gt 0) {
+    Write-Error ("planning validation failed:`n- " + ($failures -join "`n- "))
+    exit 1
+}
+
+Write-Output 'planning validation passed'

--- a/tests/roadmap_sync.rs
+++ b/tests/roadmap_sync.rs
@@ -21,6 +21,19 @@ fn write_file(path: &Path, content: &str) -> Result<()> {
     Ok(())
 }
 
+fn run_validate_planning(backlog_path: &Path, title_path: &Path) -> Result<std::process::Output> {
+    Command::new(powershell())
+        .arg("-NoProfile")
+        .arg("-File")
+        .arg(repo_root().join("scripts").join("validate-planning.ps1"))
+        .arg("-BacklogPath")
+        .arg(backlog_path)
+        .arg("-RoadmapTitleJaPath")
+        .arg(title_path)
+        .output()
+        .context("failed to run validate-planning.ps1")
+}
+
 #[test]
 fn sync_roadmap_generates_grouped_japanese_view() -> Result<()> {
     let temp = TempDir::new()?;
@@ -245,6 +258,128 @@ fn setup_planning_does_not_update_marker_when_sync_fails() -> Result<()> {
     assert_eq!(
         fs::read_to_string(&marker_path)?,
         previous_root.display().to_string()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn validate_planning_accepts_well_formed_inputs() -> Result<()> {
+    let temp = TempDir::new()?;
+    let backlog_path = temp.path().join("backlog.yaml");
+    let title_path = temp.path().join("roadmap-title-ja.psd1");
+
+    write_file(
+        &backlog_path,
+        "# === v0.1.0: Bootstrap ===\n- id: TASK-001\n    title: Create bridge foundation\n    status: done\n    priority: P0\n    target_version: v0.1.0\n    repo: codex-channels\n",
+    )?;
+    write_file(
+        &title_path,
+        "@{\n    VersionTitles = @{ \"v0.1.0\" = \"基盤\" }\n    TaskTitles = @{ \"TASK-001\" = \"ブリッジ基盤を作成\" }\n}\n",
+    )?;
+
+    let output = run_validate_planning(&backlog_path, &title_path)?;
+    assert!(
+        output.status.success(),
+        "validate-planning failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    Ok(())
+}
+
+#[test]
+fn validate_planning_rejects_missing_required_backlog_fields() -> Result<()> {
+    let temp = TempDir::new()?;
+    let backlog_path = temp.path().join("backlog.yaml");
+    let title_path = temp.path().join("roadmap-title-ja.psd1");
+
+    write_file(
+        &backlog_path,
+        "# === v0.1.0: Bootstrap ===\n- id: TASK-001\n    title: Create bridge foundation\n    status: done\n    priority: P0\n    repo: codex-channels\n",
+    )?;
+    write_file(
+        &title_path,
+        "@{\n    VersionTitles = @{}\n    TaskTitles = @{}\n}\n",
+    )?;
+
+    let output = run_validate_planning(&backlog_path, &title_path)?;
+    assert!(
+        !output.status.success(),
+        "validate-planning unexpectedly succeeded"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("target_version"),
+        "stderr did not mention missing field: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    Ok(())
+}
+
+#[test]
+fn validate_planning_rejects_invalid_localization_file() -> Result<()> {
+    let temp = TempDir::new()?;
+    let backlog_path = temp.path().join("backlog.yaml");
+    let title_path = temp.path().join("roadmap-title-ja.psd1");
+
+    write_file(
+        &backlog_path,
+        "# === v0.1.0: Bootstrap ===\n- id: TASK-001\n    title: Create bridge foundation\n    status: done\n    priority: P0\n    target_version: v0.1.0\n    repo: codex-channels\n",
+    )?;
+    write_file(&title_path, "@{\nVersionTitles =\n")?;
+
+    let output = run_validate_planning(&backlog_path, &title_path)?;
+    assert!(
+        !output.status.success(),
+        "validate-planning unexpectedly succeeded"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("roadmap-title-ja.psd1"),
+        "stderr did not mention localization file: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    Ok(())
+}
+
+#[test]
+fn validate_planning_rejects_invalid_backlog_values() -> Result<()> {
+    let temp = TempDir::new()?;
+    let backlog_path = temp.path().join("backlog.yaml");
+    let title_path = temp.path().join("roadmap-title-ja.psd1");
+
+    write_file(
+        &backlog_path,
+        "# === v0.1.0: Bootstrap ===\n- id: TASK-001\n    title: Create bridge foundation\n    status: progress\n    priority: HIGH\n    target_version: 1.0.0\n    repo: codex-channels\n\n- id: TASK-001\n    title: Add validation\n    status: active\n    priority: P1\n    target_version: v0.1.0\n    repo: codex-channels\n",
+    )?;
+    write_file(
+        &title_path,
+        "@{\n    VersionTitles = @{}\n    TaskTitles = @{}\n}\n",
+    )?;
+
+    let output = run_validate_planning(&backlog_path, &title_path)?;
+    assert!(
+        !output.status.success(),
+        "validate-planning unexpectedly succeeded"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("invalid status"),
+        "stderr missing status: {stderr}"
+    );
+    assert!(
+        stderr.contains("invalid priority"),
+        "stderr missing priority: {stderr}"
+    );
+    assert!(
+        stderr.contains("invalid target_version"),
+        "stderr missing target_version: {stderr}"
+    );
+    assert!(
+        stderr.contains("duplicated"),
+        "stderr missing duplicate: {stderr}"
     );
 
     Ok(())


### PR DESCRIPTION
## Summary
- add scripts/validate-planning.ps1 to validate backlog structure and localization syntax before roadmap sync
- call planning validation from setup-planning.ps1 and from GitHub Actions
- add integration tests that cover valid inputs, missing required fields, invalid localization syntax, and invalid backlog values

## Testing
- cargo fmt --check
- cargo test --test roadmap_sync
- cargo test
- cargo check
- pwsh -NoProfile -File scripts/validate-planning.ps1
- pwsh -NoProfile -File scripts/audit-public-surface.ps1