### PR TITLE
fix: prefer canonical planning vault during discovery

### DIFF
--- a/scripts/planning-paths.ps1
+++ b/scripts/planning-paths.ps1
@@ -34,6 +34,7 @@ function Find-CodexChannelsPlanningRoot {
 
     try {
         $backlogFiles = Get-ChildItem -LiteralPath $UserProfile -Filter 'backlog.yaml' -File -Recurse -Depth 8 -ErrorAction SilentlyContinue
+        $candidates = New-Object System.Collections.Generic.List[string]
         foreach ($file in $backlogFiles) {
             $directory = $file.DirectoryName
             if ([string]::IsNullOrWhiteSpace($directory)) {
@@ -44,9 +45,30 @@ function Find-CodexChannelsPlanningRoot {
                 continue
             }
 
-            if (Test-Path -LiteralPath (Join-Path $directory 'ROADMAP.md')) {
-                return $directory
+            if (-not (Test-Path -LiteralPath (Join-Path $directory 'ROADMAP.md'))) {
+                continue
             }
+
+            if (-not (Test-Path -LiteralPath (Join-Path $directory 'roadmap-title-ja.psd1'))) {
+                continue
+            }
+
+            $candidates.Add($directory) | Out-Null
+        }
+
+        if ($candidates.Count -eq 0) {
+            return $null
+        }
+
+        $preferred = @(
+            $candidates | Sort-Object `
+                @{ Expression = { if ($_ -match '[\\/]iCloudDrive[\\/]iCloud~md~obsidian[\\/]MainVault[\\/]Projects[\\/]codex-channels[\\/]planning$') { 0 } else { 1 } } }, `
+                @{ Expression = { $_.Length } }, `
+                @{ Expression = { $_ } }
+        )
+
+        if ($preferred.Count -gt 0) {
+            return [string]$preferred[0]
         }
     } catch {
         return $null

--- a/tests/roadmap_sync.rs
+++ b/tests/roadmap_sync.rs
@@ -200,8 +200,9 @@ fn planning_paths_prefers_mainvault_over_duplicate_vault() -> Result<()> {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let resolved = String::from_utf8(output.stdout)?.trim().to_owned();
-    assert_eq!(resolved, canonical_root.display().to_string());
+    let resolved = fs::canonicalize(String::from_utf8(output.stdout)?.trim())?;
+    let expected = fs::canonicalize(&canonical_root)?;
+    assert_eq!(resolved, expected);
 
     Ok(())
 }

--- a/tests/roadmap_sync.rs
+++ b/tests/roadmap_sync.rs
@@ -150,6 +150,63 @@ fn planning_paths_prefers_env_override() -> Result<()> {
 }
 
 #[test]
+fn planning_paths_prefers_mainvault_over_duplicate_vault() -> Result<()> {
+    let temp = TempDir::new()?;
+    let canonical_root = temp
+        .path()
+        .join("iCloudDrive")
+        .join("iCloud~md~obsidian")
+        .join("MainVault")
+        .join("Projects")
+        .join("codex-channels")
+        .join("planning");
+    let duplicate_root = temp
+        .path()
+        .join("iCloudDrive")
+        .join("iCloud~md~obsidian")
+        .join("A-MainVault")
+        .join("Projects")
+        .join("codex-channels")
+        .join("planning");
+
+    fs::create_dir_all(&canonical_root)?;
+    fs::create_dir_all(&duplicate_root)?;
+    fs::write(canonical_root.join("backlog.yaml"), "- id: TASK-001\n")?;
+    fs::write(canonical_root.join("ROADMAP.md"), "# canonical\n")?;
+    fs::write(canonical_root.join("roadmap-title-ja.psd1"), "@{\n}\n")?;
+    fs::write(duplicate_root.join("backlog.yaml"), "- id: TASK-002\n")?;
+    fs::write(duplicate_root.join("ROADMAP.md"), "# duplicate\n")?;
+
+    let script = format!(
+        ". '{}' ; Get-CodexChannelsDefaultPlanningRoot",
+        repo_root()
+            .join("scripts")
+            .join("planning-paths.ps1")
+            .display()
+    );
+
+    let output = Command::new(powershell())
+        .arg("-NoProfile")
+        .arg("-Command")
+        .arg(script)
+        .env("USERPROFILE", temp.path())
+        .env("LOCALAPPDATA", temp.path().join("LocalAppData"))
+        .output()
+        .context("failed to run planning-paths.ps1")?;
+
+    assert!(
+        output.status.success(),
+        "planning-paths failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let resolved = String::from_utf8(output.stdout)?.trim().to_owned();
+    assert_eq!(resolved, canonical_root.display().to_string());
+
+    Ok(())
+}
+
+#[test]
 fn setup_planning_creates_live_files_and_marker() -> Result<()> {
     let temp = TempDir::new()?;
     let planning_root = temp.path().join("planning-root");


### PR DESCRIPTION
## Summary
- require oadmap-title-ja.psd1 alongside acklog.yaml and ROADMAP.md when auto-discovering a planning root
- prefer the canonical MainVault/Projects/codex-channels/planning path over duplicate vault directories
- add an integration test that proves duplicate vaults do not win discovery

## Testing
- cargo fmt --check
- cargo test --test roadmap_sync planning_paths_prefers_mainvault_over_duplicate_vault
- cargo test --test roadmap_sync
- cargo test
- cargo check