### PR TITLE
feat: add automatic turn modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Implemented today:
 - `codex exec` and `codex exec resume` integration
 - attachment parsing and safe local attachment storage
 - `completion_checks` execution and automatic repair retry flow
+- automatic continuation for `infinite` and `max_turns`
 - progress message editing in Telegram
 - Telegram control commands for `/help`, `/status`, `/stop`, and `/mode`
 - DPAPI-backed local secret storage
@@ -62,6 +63,8 @@ cargo check
 /status
 /stop
 /mode completion_checks
+/mode infinite
+/mode max_turns 3
 ```
 
 6. Install the Windows service when you want background execution:
@@ -108,6 +111,7 @@ Important sections:
 - `codex`: CLI binary, model, sandbox, and approval mode
 - `storage`: SQLite path, temp path, and log path
 - `policy`: default lane behavior and output truncation
+- `policy.max_turns_limit`: default extra-turn cap for `max_turns`
 - `checks`: named completion-check profiles
 - `workspaces`: workspace mapping and default continuation prompt
 
@@ -118,6 +122,7 @@ Example `completion_checks` profile:
 default_mode = "completion_checks"
 progress_edit_interval_ms = 5000
 max_output_chars = 12000
+max_turns_limit = 3
 
 [checks.profiles.default]
 [[checks.profiles.default.commands]]
@@ -140,6 +145,14 @@ default_mode = "completion_checks"
 continue_prompt = "失敗した確認を直し、必要ならテストを追加して続けてください。"
 checks_profile = "default"
 ```
+
+Example `max_turns` control command:
+
+```text
+/mode max_turns 3
+```
+
+This keeps the lane in `waiting_reply` after up to three automatic continuation turns.
 
 ## Secret Handling
 
@@ -172,7 +185,6 @@ GitHub Actions runs:
 The `main` branch is protected and requires:
 
 - pull request based changes
-- one approval
 - resolved conversations
 - passing `ci`
 

--- a/bridge.toml
+++ b/bridge.toml
@@ -25,6 +25,7 @@ log_dir = "state/logs"
 default_mode = "await_reply"
 progress_edit_interval_ms = 5000
 max_output_chars = 12000
+max_turns_limit = 3
 
 [[workspaces]]
 id = "main"

--- a/src/config.rs
+++ b/src/config.rs
@@ -63,6 +63,8 @@ pub struct PolicyConfig {
     pub default_mode: LaneMode,
     pub progress_edit_interval_ms: u64,
     pub max_output_chars: usize,
+    #[serde(default = "default_max_turns_limit")]
+    pub max_turns_limit: i64,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -114,8 +116,14 @@ pub enum LaneMode {
     MaxTurns,
 }
 
+pub const DEFAULT_MAX_TURNS_BUDGET: i64 = 3;
+
 fn default_check_timeout_sec() -> u64 {
     300
+}
+
+fn default_max_turns_limit() -> i64 {
+    DEFAULT_MAX_TURNS_BUDGET
 }
 
 impl Config {
@@ -167,6 +175,9 @@ impl Config {
                     );
                 }
             }
+        }
+        if self.policy.max_turns_limit <= 0 {
+            bail!("policy.max_turns_limit must be greater than zero");
         }
         Ok(())
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -5,7 +5,7 @@ use tracing::{info, warn};
 
 use crate::codex::{CodexRequest, CodexRunner};
 use crate::config::{Config, LaneMode, checks::CheckRunSummary, checks::run_profile};
-use crate::store::{AuthorizedSender, LaneState, NewRun, Store};
+use crate::store::{AuthorizedSender, LaneRecord, LaneState, NewRun, Store};
 use crate::telegram::{
     IncomingMessage, SavedTelegramAttachment, TelegramAttachmentKind, TelegramClient,
     TelegramControlCommand,
@@ -14,6 +14,8 @@ use crate::windows_secret::load_secret;
 
 const MAX_COMPLETION_REPAIR_TURNS: usize = 2;
 const MAX_TELEGRAM_ATTACHMENT_BYTES: usize = 20 * 1024 * 1024;
+const MAX_INFINITE_AUTO_TURNS: usize = 16;
+const AUTO_CONTINUE_STOP_MARKER: &str = "CHANNEL_WAITING";
 
 pub async fn run_console(config: Config) -> Result<()> {
     let shutdown = CancellationToken::new();
@@ -110,6 +112,7 @@ async fn handle_message(
             update.chat_id,
             &update.thread_key,
             command,
+            config.policy.max_turns_limit,
         )?;
         let sent = telegram.send_message(update.chat_id, &reply).await?;
         if let Some(lane) = store.find_lane(update.chat_id, &update.thread_key)? {
@@ -131,6 +134,7 @@ async fn handle_message(
         &update.thread_key,
         &workspace.id,
         workspace.default_mode,
+        configured_extra_turn_budget(workspace.default_mode, None, config.policy.max_turns_limit),
     )?;
 
     store.insert_message(
@@ -184,17 +188,17 @@ async fn handle_message(
             .await?
     };
     let request = build_user_request(&update.text, &saved_attachments);
-    let outcome = if let Some(session_id) = lane.codex_session_id.as_deref() {
+    let initial_outcome = if let Some(session_id) = lane.codex_session_id.as_deref() {
         codex.resume(workspace, session_id, request).await?
     } else {
         codex.start(workspace, request).await?
     };
-    let (outcome, unresolved_checks) =
-        settle_completion_checks(config, workspace, codex, lane.mode, outcome).await?;
+    let (outcome, unresolved_checks, auto_turns_completed) =
+        continue_lane_after_completion(config, workspace, codex, &lane, initial_outcome).await?;
 
     let reply = if let Some(summary) = unresolved_checks.as_ref() {
         truncate(
-            &format_reply_with_failed_checks(&outcome.last_message, summary),
+            &format_reply_with_failed_checks(&outcome.last_message, summary, auto_turns_completed),
             config.policy.max_output_chars,
         )
     } else if outcome.last_message.trim().is_empty() {
@@ -255,12 +259,14 @@ fn handle_control_command(
     chat_id: i64,
     thread_key: &str,
     command: TelegramControlCommand,
+    default_max_turns_limit: i64,
 ) -> Result<String> {
     match command {
         TelegramControlCommand::Help => Ok(format_help_message()),
-        TelegramControlCommand::Status => {
-            Ok(format_status_message(store.find_lane(chat_id, thread_key)?))
-        }
+        TelegramControlCommand::Status => Ok(format_status_message(
+            store.find_lane(chat_id, thread_key)?,
+            default_max_turns_limit,
+        )),
         TelegramControlCommand::Stop => {
             let Some(lane) = store.find_lane(chat_id, thread_key)? else {
                 return Ok("停止する対象はありません。".to_owned());
@@ -268,13 +274,22 @@ fn handle_control_command(
             store.clear_lane_session(&lane.lane_id)?;
             Ok("現在のセッションを止めました。次の入力は新しい開始として扱います。".to_owned())
         }
-        TelegramControlCommand::Mode(raw_mode) => {
-            let mode = parse_lane_mode_name(&raw_mode)?;
-            let lane = store.get_or_create_lane(chat_id, thread_key, &workspace.id, mode)?;
-            store.update_lane_mode(&lane.lane_id, mode)?;
+        TelegramControlCommand::Mode { mode, max_turns } => {
+            let mode = parse_lane_mode_name(&mode)?;
+            let extra_turn_budget =
+                configured_extra_turn_budget(mode, max_turns, default_max_turns_limit);
+            let lane = store.get_or_create_lane(
+                chat_id,
+                thread_key,
+                &workspace.id,
+                mode,
+                extra_turn_budget,
+            )?;
+            store.update_lane_mode(&lane.lane_id, mode, extra_turn_budget)?;
             Ok(format!(
-                "この会話のモードを `{}` に更新しました。",
-                lane_mode_name(mode)
+                "この会話のモードを {} に更新しました。{}",
+                lane_mode_name(mode),
+                format_lane_mode_details(mode, extra_turn_budget)
             ))
         }
     }
@@ -331,6 +346,57 @@ async fn settle_completion_checks(
     Ok((outcome, None))
 }
 
+async fn continue_lane_after_completion(
+    config: &Config,
+    workspace: &crate::config::WorkspaceConfig,
+    codex: &CodexRunner,
+    lane: &LaneRecord,
+    initial_outcome: crate::codex::CodexOutcome,
+) -> Result<(crate::codex::CodexOutcome, Option<CheckRunSummary>, usize)> {
+    let (mut outcome, mut unresolved_checks) =
+        settle_completion_checks(config, workspace, codex, lane.mode, initial_outcome).await?;
+    let mut auto_turns_completed = 0usize;
+    let mut last_visible_message = sanitize_auto_continue_message(&outcome.last_message);
+    let auto_turn_limit = automatic_turn_limit(
+        lane.mode,
+        lane.extra_turn_budget,
+        config.policy.max_turns_limit,
+    );
+
+    while should_continue_automatically(
+        lane.mode,
+        auto_turn_limit,
+        auto_turns_completed,
+        &outcome,
+        unresolved_checks.as_ref(),
+    ) {
+        let session_id = outcome
+            .session_id
+            .as_deref()
+            .ok_or_else(|| anyhow!("missing session_id for auto-continue"))?;
+        let resumed = codex
+            .resume(
+                workspace,
+                session_id,
+                build_auto_continue_prompt(&workspace.continue_prompt),
+            )
+            .await?;
+        auto_turns_completed += 1;
+
+        let (next_outcome, next_unresolved_checks) =
+            settle_completion_checks(config, workspace, codex, lane.mode, resumed).await?;
+        let visible_message = sanitize_auto_continue_message(&next_outcome.last_message);
+        if !visible_message.trim().is_empty() {
+            last_visible_message = visible_message;
+        }
+        outcome = next_outcome;
+        unresolved_checks = next_unresolved_checks;
+    }
+
+    outcome.last_message = last_visible_message;
+    Ok((outcome, unresolved_checks, auto_turns_completed))
+}
+
 fn format_processing_message(is_resume: bool) -> String {
     if is_resume {
         "前回の続きとして処理しています。完了したら、このメッセージを更新します。".to_owned()
@@ -350,12 +416,18 @@ fn format_help_message() -> String {
         "/help",
         "/status",
         "/stop",
-        "/mode await_reply|completion_checks|infinite|max_turns",
+        "/mode await_reply",
+        "/mode completion_checks",
+        "/mode infinite",
+        "/mode max_turns [count]",
     ]
     .join("\n")
 }
 
-fn format_status_message(lane: Option<crate::store::LaneRecord>) -> String {
+fn format_status_message(
+    lane: Option<crate::store::LaneRecord>,
+    default_max_turns_limit: i64,
+) -> String {
     let Some(lane) = lane else {
         return "この会話にはまだレーンがありません。".to_owned();
     };
@@ -365,10 +437,16 @@ fn format_status_message(lane: Option<crate::store::LaneRecord>) -> String {
     } else {
         "なし"
     };
+    let configured_budget = configured_extra_turn_budget(
+        lane.mode,
+        Some(lane.extra_turn_budget),
+        default_max_turns_limit,
+    );
     format!(
-        "状態: `{}`\nモード: `{}`\nセッション: {}",
+        "状態: `{}`\nモード: `{}`\n{}\nセッション: {}",
         lane_state_name(lane.state),
         lane_mode_name(lane.mode),
+        format_lane_mode_details(lane.mode, configured_budget),
         session
     )
 }
@@ -413,16 +491,104 @@ fn build_completion_retry_prompt(continue_prompt: &str, summary: &CheckRunSummar
     )
 }
 
-fn format_reply_with_failed_checks(last_message: &str, summary: &CheckRunSummary) -> String {
+fn format_reply_with_failed_checks(
+    last_message: &str,
+    summary: &CheckRunSummary,
+    auto_turns_completed: usize,
+) -> String {
     let mut sections = Vec::new();
     if !last_message.trim().is_empty() {
         sections.push(truncate(last_message, usize::MAX));
+    }
+    if auto_turns_completed > 0 {
+        sections.push(format!(
+            "自動継続を {} 回実行したあとで止まりました。",
+            auto_turns_completed
+        ));
     }
     sections.push(format!(
         "確認で失敗しました。ローカルで追加の修正が必要です。\n{}",
         summary.summary()
     ));
     sections.join("\n\n")
+}
+
+fn build_auto_continue_prompt(continue_prompt: &str) -> String {
+    format!(
+        "{continue_prompt}\n\nまだ続ける作業がある時だけ続けてください。区切りがついたら `{AUTO_CONTINUE_STOP_MARKER}` とだけ返してください。"
+    )
+}
+
+fn sanitize_auto_continue_message(message: &str) -> String {
+    if message.trim() == AUTO_CONTINUE_STOP_MARKER {
+        String::new()
+    } else {
+        message.to_owned()
+    }
+}
+
+fn automatic_turn_limit(
+    mode: LaneMode,
+    configured_budget: i64,
+    default_max_turns_limit: i64,
+) -> Option<usize> {
+    match mode {
+        LaneMode::Infinite => None,
+        LaneMode::MaxTurns => Some(configured_extra_turn_budget(
+            mode,
+            Some(configured_budget),
+            default_max_turns_limit,
+        ) as usize),
+        LaneMode::AwaitReply | LaneMode::CompletionChecks => Some(0),
+    }
+}
+
+fn should_continue_automatically(
+    mode: LaneMode,
+    auto_turn_limit: Option<usize>,
+    auto_turns_completed: usize,
+    outcome: &crate::codex::CodexOutcome,
+    unresolved_checks: Option<&CheckRunSummary>,
+) -> bool {
+    if matches!(mode, LaneMode::AwaitReply | LaneMode::CompletionChecks) {
+        return false;
+    }
+    if outcome.approval_pending
+        || unresolved_checks.is_some()
+        || outcome.session_id.is_none()
+        || outcome.last_message.trim().is_empty()
+        || outcome.last_message.trim() == AUTO_CONTINUE_STOP_MARKER
+    {
+        return false;
+    }
+    match mode {
+        LaneMode::Infinite => auto_turns_completed < MAX_INFINITE_AUTO_TURNS,
+        LaneMode::MaxTurns => auto_turn_limit
+            .map(|limit| auto_turns_completed < limit)
+            .unwrap_or(false),
+        LaneMode::AwaitReply | LaneMode::CompletionChecks => false,
+    }
+}
+
+fn configured_extra_turn_budget(
+    mode: LaneMode,
+    requested_budget: Option<i64>,
+    default_max_turns_limit: i64,
+) -> i64 {
+    match mode {
+        LaneMode::MaxTurns => requested_budget
+            .filter(|value| *value > 0)
+            .unwrap_or(default_max_turns_limit),
+        LaneMode::AwaitReply | LaneMode::CompletionChecks | LaneMode::Infinite => 0,
+    }
+}
+
+fn format_lane_mode_details(mode: LaneMode, extra_turn_budget: i64) -> String {
+    match mode {
+        LaneMode::MaxTurns => format!("追加ターン上限: {}", extra_turn_budget),
+        LaneMode::Infinite => format!("自動継続: 安全上限 {} 回/入力", MAX_INFINITE_AUTO_TURNS),
+        LaneMode::AwaitReply | LaneMode::CompletionChecks => "追加ターン上限: なし".to_owned(),
+    }
 }
 
 fn parse_lane_mode_name(value: &str) -> Result<LaneMode> {
@@ -517,8 +683,9 @@ mod tests {
 
     #[test]
     fn failed_check_reply_includes_agent_message_and_summary() {
-        let reply = format_reply_with_failed_checks("修正を試しました。", &failed_summary());
+        let reply = format_reply_with_failed_checks("修正を試しました。", &failed_summary(), 2);
         assert!(reply.contains("修正を試しました。"));
+        assert!(reply.contains("自動継続を 2 回実行"));
         assert!(reply.contains("確認で失敗しました。"));
         assert!(reply.contains("completion checks failed on 'cargo test'"));
     }
@@ -558,7 +725,7 @@ mod tests {
     #[test]
     fn format_status_message_without_lane_is_clear() {
         assert_eq!(
-            format_status_message(None),
+            format_status_message(None, 3),
             "この会話にはまだレーンがありません。"
         );
     }
@@ -588,7 +755,11 @@ mod tests {
             &workspace,
             10,
             "dm",
-            TelegramControlCommand::Mode("completion_checks".to_owned()),
+            TelegramControlCommand::Mode {
+                mode: "completion_checks".to_owned(),
+                max_turns: None,
+            },
+            3,
         )
         .expect("mode command should succeed");
 
@@ -601,20 +772,54 @@ mod tests {
     }
 
     #[test]
+    fn mode_command_updates_max_turns_budget() {
+        let dir = tempdir().expect("tempdir should be created");
+        let store = Store::open(dir.path().join("bridge.db")).expect("store should open");
+        let workspace = test_workspace();
+
+        let reply = handle_control_command(
+            &store,
+            &workspace,
+            10,
+            "dm",
+            TelegramControlCommand::Mode {
+                mode: "max_turns".to_owned(),
+                max_turns: Some(5),
+            },
+            3,
+        )
+        .expect("mode command should succeed");
+
+        let lane = store
+            .find_lane(10, "dm")
+            .expect("lane lookup should succeed")
+            .expect("lane should exist");
+        assert_eq!(lane.mode, LaneMode::MaxTurns);
+        assert_eq!(lane.extra_turn_budget, 5);
+        assert!(reply.contains("追加ターン上限: 5"));
+    }
+
+    #[test]
     fn stop_command_clears_session() {
         let dir = tempdir().expect("tempdir should be created");
         let store = Store::open(dir.path().join("bridge.db")).expect("store should open");
         let workspace = test_workspace();
         let lane = store
-            .get_or_create_lane(20, "dm", &workspace.id, LaneMode::AwaitReply)
+            .get_or_create_lane(20, "dm", &workspace.id, LaneMode::AwaitReply, 0)
             .expect("lane should be created");
         store
             .update_lane_state(&lane.lane_id, LaneState::WaitingReply, Some("session-1"))
             .expect("lane should update");
 
-        let reply =
-            handle_control_command(&store, &workspace, 20, "dm", TelegramControlCommand::Stop)
-                .expect("stop command should succeed");
+        let reply = handle_control_command(
+            &store,
+            &workspace,
+            20,
+            "dm",
+            TelegramControlCommand::Stop,
+            3,
+        )
+        .expect("stop command should succeed");
 
         let lane = store
             .find_lane(20, "dm")
@@ -662,5 +867,47 @@ mod tests {
             continue_prompt: "continue".to_owned(),
             checks_profile: "default".to_owned(),
         }
+    }
+
+    #[test]
+    fn automatic_turn_limit_uses_default_for_zero_budget() {
+        assert_eq!(automatic_turn_limit(LaneMode::MaxTurns, 0, 4), Some(4));
+    }
+
+    #[test]
+    fn sanitize_auto_continue_message_hides_stop_marker() {
+        assert_eq!(
+            sanitize_auto_continue_message(AUTO_CONTINUE_STOP_MARKER),
+            ""
+        );
+        assert_eq!(
+            sanitize_auto_continue_message("修正しました。"),
+            "修正しました。"
+        );
+    }
+
+    #[test]
+    fn should_continue_automatically_for_max_turns_until_limit() {
+        let outcome = crate::codex::CodexOutcome {
+            session_id: Some("session-1".to_owned()),
+            last_message: "続けます".to_owned(),
+            exit_code: Some(0),
+            approval_pending: false,
+        };
+
+        assert!(should_continue_automatically(
+            LaneMode::MaxTurns,
+            Some(2),
+            1,
+            &outcome,
+            None,
+        ));
+        assert!(!should_continue_automatically(
+            LaneMode::MaxTurns,
+            Some(2),
+            2,
+            &outcome,
+            None,
+        ));
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -216,6 +216,7 @@ impl Store {
         thread_key: &str,
         workspace_id: &str,
         mode: LaneMode,
+        extra_turn_budget: i64,
     ) -> Result<LaneRecord> {
         if let Some(lane) = self.find_lane(chat_id, thread_key)? {
             return Ok(lane);
@@ -228,7 +229,7 @@ impl Store {
             mode,
             state: LaneState::Idle,
             codex_session_id: None,
-            extra_turn_budget: 0,
+            extra_turn_budget,
             waiting_since_ms: None,
         };
         self.with_conn(|conn| {
@@ -339,15 +340,21 @@ impl Store {
         Ok(())
     }
 
-    pub fn update_lane_mode(&self, lane_id: &str, mode: LaneMode) -> Result<()> {
+    pub fn update_lane_mode(
+        &self,
+        lane_id: &str,
+        mode: LaneMode,
+        extra_turn_budget: i64,
+    ) -> Result<()> {
         self.with_conn(|conn| {
             conn.execute(
                 r#"
                 UPDATE lanes
-                SET mode = ?2
+                SET mode = ?2,
+                    extra_turn_budget = ?3
                 WHERE lane_id = ?1
                 "#,
-                params![lane_id, mode_to_str(mode)],
+                params![lane_id, mode_to_str(mode), extra_turn_budget],
             )
         })?;
         Ok(())
@@ -480,7 +487,7 @@ mod tests {
     fn find_lane_returns_lane_for_chat_and_thread() {
         let (_dir, store) = temp_store();
         let created = store
-            .get_or_create_lane(42, "555", "workspace", LaneMode::AwaitReply)
+            .get_or_create_lane(42, "555", "workspace", LaneMode::AwaitReply, 0)
             .expect("lane");
 
         let fetched = store
@@ -497,7 +504,7 @@ mod tests {
     fn clear_lane_session_resets_session_fields_and_state() {
         let (_dir, store) = temp_store();
         let lane = store
-            .get_or_create_lane(42, "555", "workspace", LaneMode::CompletionChecks)
+            .get_or_create_lane(42, "555", "workspace", LaneMode::CompletionChecks, 0)
             .expect("lane");
         store
             .update_lane_state(&lane.lane_id, LaneState::WaitingReply, Some("session-1"))
@@ -527,17 +534,17 @@ mod tests {
     }
 
     #[test]
-    fn update_lane_mode_changes_only_mode() {
+    fn update_lane_mode_changes_mode_and_budget() {
         let (_dir, store) = temp_store();
         let lane = store
-            .get_or_create_lane(42, "555", "workspace", LaneMode::AwaitReply)
+            .get_or_create_lane(42, "555", "workspace", LaneMode::AwaitReply, 0)
             .expect("lane");
         store
             .update_lane_state(&lane.lane_id, LaneState::WaitingReply, Some("session-1"))
             .expect("state update");
 
         store
-            .update_lane_mode(&lane.lane_id, LaneMode::MaxTurns)
+            .update_lane_mode(&lane.lane_id, LaneMode::MaxTurns, 5)
             .expect("mode update");
 
         let lane = store
@@ -545,8 +552,20 @@ mod tests {
             .expect("query")
             .expect("lane exists");
         assert_eq!(lane.mode, LaneMode::MaxTurns);
+        assert_eq!(lane.extra_turn_budget, 5);
         assert_eq!(lane.state, LaneState::WaitingReply);
         assert_eq!(lane.codex_session_id.as_deref(), Some("session-1"));
         assert!(lane.waiting_since_ms.is_some());
+    }
+
+    #[test]
+    fn create_lane_uses_requested_budget_for_max_turns() {
+        let (_dir, store) = temp_store();
+
+        let lane = store
+            .get_or_create_lane(42, "555", "workspace", LaneMode::MaxTurns, 4)
+            .expect("lane");
+
+        assert_eq!(lane.extra_turn_budget, 4);
     }
 }

--- a/src/telegram.rs
+++ b/src/telegram.rs
@@ -31,7 +31,10 @@ pub enum TelegramControlCommand {
     Help,
     Status,
     Stop,
-    Mode(String),
+    Mode {
+        mode: String,
+        max_turns: Option<i64>,
+    },
 }
 
 impl IncomingMessage {
@@ -506,11 +509,24 @@ pub fn parse_control_command(text: &str) -> Option<TelegramControlCommand> {
             .then_some(TelegramControlCommand::Stop);
     }
     if command.eq_ignore_ascii_case("mode") {
-        let value = parts.next()?.trim();
-        if value.is_empty() || parts.next().is_some() {
+        let mode = parts.next()?.trim().to_ascii_lowercase();
+        if mode.is_empty() {
             return None;
         }
-        return Some(TelegramControlCommand::Mode(value.to_ascii_lowercase()));
+        let max_turns = match parts.next() {
+            Some(raw_budget) => {
+                if !mode.eq_ignore_ascii_case("max_turns") || parts.next().is_some() {
+                    return None;
+                }
+                let parsed = raw_budget.parse::<i64>().ok()?;
+                if parsed <= 0 {
+                    return None;
+                }
+                Some(parsed)
+            }
+            None => None,
+        };
+        return Some(TelegramControlCommand::Mode { mode, max_turns });
     }
 
     None
@@ -980,7 +996,21 @@ mod tests {
     fn parses_mode_command_argument() {
         assert_eq!(
             parse_control_command("/mode completion_checks"),
-            Some(TelegramControlCommand::Mode("completion_checks".to_owned()))
+            Some(TelegramControlCommand::Mode {
+                mode: "completion_checks".to_owned(),
+                max_turns: None,
+            })
+        );
+    }
+
+    #[test]
+    fn parses_mode_command_with_max_turns_budget() {
+        assert_eq!(
+            parse_control_command("/mode max_turns 5"),
+            Some(TelegramControlCommand::Mode {
+                mode: "max_turns".to_owned(),
+                max_turns: Some(5),
+            })
         );
     }
 
@@ -1027,5 +1057,7 @@ mod tests {
     #[test]
     fn rejects_mode_command_with_extra_arguments() {
         assert_eq!(parse_control_command("/mode completion checks"), None);
+        assert_eq!(parse_control_command("/mode max_turns 3 extra"), None);
+        assert_eq!(parse_control_command("/mode max_turns 0"), None);
     }
 }

--- a/tests/checks_runner.rs
+++ b/tests/checks_runner.rs
@@ -2,7 +2,9 @@ use std::fs;
 use std::path::Path;
 
 use anyhow::Result;
-use codex_telegram_bridge::config::{CheckCommand, CheckProfile, Config, checks::run_profile};
+use codex_telegram_bridge::config::{
+    CheckCommand, CheckProfile, Config, DEFAULT_MAX_TURNS_BUDGET, checks::run_profile,
+};
 use tempfile::tempdir;
 
 #[test]
@@ -39,6 +41,7 @@ log_dir = "state/logs"
 default_mode = "completion_checks"
 progress_edit_interval_ms = 5000
 max_output_chars = 12000
+max_turns_limit = 4
 
 [checks.profiles.quick]
 [[checks.profiles.quick.commands]]
@@ -75,6 +78,112 @@ checks_profile = "quick"
     assert_eq!(profile.commands[0].program, "cargo");
     assert_eq!(profile.commands[0].args, vec!["fmt", "--check"]);
     assert_eq!(profile.commands[1].timeout_sec, 90);
+    assert_eq!(config.policy.max_turns_limit, 4);
+    Ok(())
+}
+
+#[test]
+fn config_uses_default_max_turns_limit_when_omitted() -> Result<()> {
+    let dir = tempdir()?;
+    let config_path = dir.path().join("bridge.toml");
+    fs::write(
+        &config_path,
+        r#"
+[service]
+run_mode = "console"
+poll_timeout_sec = 30
+shutdown_grace_sec = 15
+
+[telegram]
+token_secret_ref = "secret"
+allowed_chat_types = ["private"]
+admin_sender_ids = [1]
+
+[codex]
+binary = "codex"
+model = "gpt-5.4"
+sandbox = "workspace-write"
+approval = "on-request"
+profile = "default"
+
+[storage]
+db_path = "state/bridge.db"
+state_dir = "state"
+temp_dir = "state/tmp"
+log_dir = "state/logs"
+
+[policy]
+default_mode = "await_reply"
+progress_edit_interval_ms = 5000
+max_output_chars = 12000
+
+[[workspaces]]
+id = "main"
+path = "C:/workspace"
+writable_roots = ["C:/workspace"]
+default_mode = "await_reply"
+continue_prompt = "continue"
+checks_profile = "default"
+"#,
+    )?;
+
+    let config = Config::load(&config_path)?;
+    assert_eq!(config.policy.max_turns_limit, DEFAULT_MAX_TURNS_BUDGET);
+    Ok(())
+}
+
+#[test]
+fn config_rejects_non_positive_max_turns_limit() -> Result<()> {
+    let dir = tempdir()?;
+    let config_path = dir.path().join("bridge.toml");
+    fs::write(
+        &config_path,
+        r#"
+[service]
+run_mode = "console"
+poll_timeout_sec = 30
+shutdown_grace_sec = 15
+
+[telegram]
+token_secret_ref = "secret"
+allowed_chat_types = ["private"]
+admin_sender_ids = [1]
+
+[codex]
+binary = "codex"
+model = "gpt-5.4"
+sandbox = "workspace-write"
+approval = "on-request"
+profile = "default"
+
+[storage]
+db_path = "state/bridge.db"
+state_dir = "state"
+temp_dir = "state/tmp"
+log_dir = "state/logs"
+
+[policy]
+default_mode = "await_reply"
+progress_edit_interval_ms = 5000
+max_output_chars = 12000
+max_turns_limit = 0
+
+[[workspaces]]
+id = "main"
+path = "C:/workspace"
+writable_roots = ["C:/workspace"]
+default_mode = "await_reply"
+continue_prompt = "continue"
+checks_profile = "default"
+"#,
+    )?;
+
+    let error = Config::load(&config_path).expect_err("config should fail");
+    assert!(
+        error
+            .to_string()
+            .contains("policy.max_turns_limit must be greater than zero")
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- add automatic continuation support for infinite and max_turns
- allow /mode max_turns N and validate policy.max_turns_limit
- document the new mode behavior and cover it with tests

## Testing
- cargo fmt --check
- cargo test
- cargo check
- pwsh -NoProfile -File scripts/audit-public-surface.ps1

## Review
- attempted /review via codex exec --sandbox read-only --full-auto, but it timed out after 124 seconds; completed manual review instead