### PR TITLE
fix: make codex profile optional for live runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Important sections:
 - `service`: run mode and shutdown timing
 - `telegram`: allowed chat types and admin sender IDs
 - `codex`: CLI binary, model, sandbox, and approval mode
+- `codex.profile`: omit by default; omission delegates profile selection to the local `codex` CLI
 - `storage`: SQLite path, temp path, and log path
 - `policy`: default lane behavior and output truncation
 - `policy.max_turns_limit`: `max_turns` の既定値であり、指定できる上限
@@ -196,7 +197,10 @@ Required environment variables:
 Optional environment variables:
 
 - `LIVE_CODEX_BIN`
+- `LIVE_CODEX_PROFILE`
 - `LIVE_TIMEOUT_SEC`
+
+The live smoke omits `codex.profile` by default and therefore follows the local `codex` CLI default. If you use a named profile, set `LIVE_CODEX_PROFILE` or add `codex.profile` to your own `bridge.toml`.
 
 Run command:
 

--- a/bridge.toml
+++ b/bridge.toml
@@ -13,7 +13,6 @@ binary = "codex"
 model = "gpt-5.4"
 sandbox = "workspace-write"
 approval = "on-request"
-profile = "default"
 
 [storage]
 db_path = "state/bridge.db"

--- a/src/codex.rs
+++ b/src/codex.rs
@@ -106,7 +106,7 @@ impl CodexRunner {
     }
 
     fn base_args(&self, workspace: &WorkspaceConfig) -> Vec<String> {
-        vec![
+        let mut args = vec![
             "exec".to_owned(),
             "--json".to_owned(),
             "--skip-git-repo-check".to_owned(),
@@ -114,13 +114,22 @@ impl CodexRunner {
             self.config.sandbox.clone(),
             "--model".to_owned(),
             self.config.model.clone(),
-            "--profile".to_owned(),
-            self.config.profile.clone(),
             "--config".to_owned(),
             format!("approval_policy=\"{}\"", self.config.approval),
             "--cd".to_owned(),
             workspace.path.display().to_string(),
-        ]
+        ];
+        if let Some(profile) = self
+            .config
+            .profile
+            .as_deref()
+            .map(str::trim)
+            .filter(|profile| !profile.is_empty())
+        {
+            args.push("--profile".to_owned());
+            args.push(profile.to_owned());
+        }
+        args
     }
 
     async fn run_command(&self, args: Vec<String>, cwd: &std::path::Path) -> Result<CodexOutcome> {
@@ -202,8 +211,10 @@ impl CodexRunner {
 
 #[cfg(test)]
 mod tests {
-    use super::CodexRequest;
+    use super::{CodexRequest, CodexRunner};
     use std::path::PathBuf;
+
+    use crate::config::{CodexConfig, LaneMode, WorkspaceConfig};
 
     #[test]
     fn request_without_images_keeps_prompt_only() {
@@ -233,5 +244,50 @@ mod tests {
                 "C:/tmp/two.png".to_owned(),
             ]
         );
+    }
+
+    #[test]
+    fn base_args_omit_profile_when_not_configured() {
+        let runner = CodexRunner::new(CodexConfig {
+            binary: "codex".to_owned(),
+            model: "gpt-5.4".to_owned(),
+            sandbox: "read-only".to_owned(),
+            approval: "never".to_owned(),
+            profile: None,
+        });
+
+        let args = runner.base_args(&workspace());
+
+        assert!(!args.iter().any(|arg| arg == "--profile"));
+    }
+
+    #[test]
+    fn base_args_include_profile_when_configured() {
+        let runner = CodexRunner::new(CodexConfig {
+            binary: "codex".to_owned(),
+            model: "gpt-5.4".to_owned(),
+            sandbox: "read-only".to_owned(),
+            approval: "never".to_owned(),
+            profile: Some("work".to_owned()),
+        });
+
+        let args = runner.base_args(&workspace());
+        let profile_index = args
+            .iter()
+            .position(|arg| arg == "--profile")
+            .expect("missing --profile");
+
+        assert_eq!(args.get(profile_index + 1), Some(&"work".to_owned()));
+    }
+
+    fn workspace() -> WorkspaceConfig {
+        WorkspaceConfig {
+            id: "main".to_owned(),
+            path: PathBuf::from("C:/workspace"),
+            writable_roots: vec![PathBuf::from("C:/workspace")],
+            default_mode: LaneMode::AwaitReply,
+            continue_prompt: "continue".to_owned(),
+            checks_profile: "default".to_owned(),
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,7 +47,8 @@ pub struct CodexConfig {
     pub model: String,
     pub sandbox: String,
     pub approval: String,
-    pub profile: String,
+    #[serde(default)]
+    pub profile: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -139,6 +140,11 @@ impl Config {
     fn validate(&self) -> Result<()> {
         if self.telegram.admin_sender_ids.is_empty() {
             bail!("telegram.admin_sender_ids must not be empty");
+        }
+        if let Some(profile) = self.codex.profile.as_deref() {
+            if profile.trim().is_empty() {
+                bail!("codex.profile must not be blank");
+            }
         }
         if self.workspaces.is_empty() {
             bail!("workspaces must not be empty");

--- a/tests/checks_runner.rs
+++ b/tests/checks_runner.rs
@@ -29,7 +29,6 @@ binary = "codex"
 model = "gpt-5.4"
 sandbox = "workspace-write"
 approval = "on-request"
-profile = "default"
 
 [storage]
 db_path = "state/bridge.db"
@@ -104,7 +103,6 @@ binary = "codex"
 model = "gpt-5.4"
 sandbox = "workspace-write"
 approval = "on-request"
-profile = "default"
 
 [storage]
 db_path = "state/bridge.db"
@@ -129,6 +127,113 @@ checks_profile = "default"
 
     let config = Config::load(&config_path)?;
     assert_eq!(config.policy.max_turns_limit, DEFAULT_MAX_TURNS_BUDGET);
+    assert_eq!(config.codex.profile, None);
+    Ok(())
+}
+
+#[test]
+fn config_loads_explicit_codex_profile() -> Result<()> {
+    let dir = tempdir()?;
+    let config_path = dir.path().join("bridge.toml");
+    fs::write(
+        &config_path,
+        r#"
+[service]
+run_mode = "console"
+poll_timeout_sec = 30
+shutdown_grace_sec = 15
+
+[telegram]
+token_secret_ref = "secret"
+allowed_chat_types = ["private"]
+admin_sender_ids = [1]
+
+[codex]
+binary = "codex"
+model = "gpt-5.4"
+sandbox = "workspace-write"
+approval = "on-request"
+profile = "work"
+
+[storage]
+db_path = "state/bridge.db"
+state_dir = "state"
+temp_dir = "state/tmp"
+log_dir = "state/logs"
+
+[policy]
+default_mode = "await_reply"
+progress_edit_interval_ms = 5000
+max_output_chars = 12000
+
+[[workspaces]]
+id = "main"
+path = "C:/workspace"
+writable_roots = ["C:/workspace"]
+default_mode = "await_reply"
+continue_prompt = "continue"
+checks_profile = "default"
+"#,
+    )?;
+
+    let config = Config::load(&config_path)?;
+
+    assert_eq!(config.codex.profile.as_deref(), Some("work"));
+    Ok(())
+}
+
+#[test]
+fn config_rejects_blank_codex_profile() -> Result<()> {
+    let dir = tempdir()?;
+    let config_path = dir.path().join("bridge.toml");
+    fs::write(
+        &config_path,
+        r#"
+[service]
+run_mode = "console"
+poll_timeout_sec = 30
+shutdown_grace_sec = 15
+
+[telegram]
+token_secret_ref = "secret"
+allowed_chat_types = ["private"]
+admin_sender_ids = [1]
+
+[codex]
+binary = "codex"
+model = "gpt-5.4"
+sandbox = "workspace-write"
+approval = "on-request"
+profile = "   "
+
+[storage]
+db_path = "state/bridge.db"
+state_dir = "state"
+temp_dir = "state/tmp"
+log_dir = "state/logs"
+
+[policy]
+default_mode = "await_reply"
+progress_edit_interval_ms = 5000
+max_output_chars = 12000
+
+[[workspaces]]
+id = "main"
+path = "C:/workspace"
+writable_roots = ["C:/workspace"]
+default_mode = "await_reply"
+continue_prompt = "continue"
+checks_profile = "default"
+"#,
+    )?;
+
+    let error = Config::load(&config_path).expect_err("config should fail");
+
+    assert!(
+        error
+            .to_string()
+            .contains("codex.profile must not be blank")
+    );
     Ok(())
 }
 
@@ -154,7 +259,6 @@ binary = "codex"
 model = "gpt-5.4"
 sandbox = "workspace-write"
 approval = "on-request"
-profile = "default"
 
 [storage]
 db_path = "state/bridge.db"

--- a/tests/live_end_to_end.rs
+++ b/tests/live_end_to_end.rs
@@ -57,6 +57,7 @@ struct LiveEnv {
     sender_id: i64,
     workspace: PathBuf,
     codex_bin: String,
+    codex_profile: Option<String>,
     timeout_sec: u64,
 }
 
@@ -72,6 +73,10 @@ impl LiveEnv {
                 .context("LIVE_TELEGRAM_SENDER_ID must be an integer")?,
             workspace: PathBuf::from(required_env("LIVE_WORKSPACE")?),
             codex_bin: env::var("LIVE_CODEX_BIN").unwrap_or_else(|_| "codex".to_owned()),
+            codex_profile: env::var("LIVE_CODEX_PROFILE")
+                .ok()
+                .map(|value| value.trim().to_owned())
+                .filter(|value| !value.is_empty()),
             timeout_sec: env::var("LIVE_TIMEOUT_SEC")
                 .ok()
                 .and_then(|value| value.parse().ok())
@@ -95,6 +100,11 @@ fn write_live_config(root: &Path, live: &LiveEnv) -> Result<PathBuf> {
     fs::create_dir_all(&temp_dir)?;
     fs::create_dir_all(&log_dir)?;
     let config_path = root.join("bridge.toml");
+    let profile_line = live
+        .codex_profile
+        .as_deref()
+        .map(|profile| format!("profile = {}\n", toml_string(profile)))
+        .unwrap_or_default();
     let config = format!(
         r#"[service]
 run_mode = "console"
@@ -111,7 +121,7 @@ binary = {codex_bin}
 model = "gpt-5.4"
 sandbox = "read-only"
 approval = "never"
-profile = "default"
+{profile_line}
 
 [storage]
 db_path = {db_path}
@@ -135,6 +145,7 @@ checks_profile = "default"
 "#,
         sender_id = live.sender_id,
         codex_bin = toml_string(&live.codex_bin),
+        profile_line = profile_line,
         db_path = toml_string(&state_dir.join("bridge.db").display().to_string()),
         state_dir = toml_string(&state_dir.display().to_string()),
         temp_dir = toml_string(&temp_dir.display().to_string()),


### PR DESCRIPTION
## Summary
- make `codex.profile` optional and reject blank values
- stop forcing `--profile default` in sample and live-generated configs
- add config tests and optional `LIVE_CODEX_PROFILE` support for live smoke

## Verification
- cargo fmt --check
- cargo test
- cargo check --features live-e2e --test live_end_to_end
- codex exec --sandbox read-only --skip-git-repo-check --model gpt-5.4 --config approval_policy=never "Reply with the exact text LOCAL_CODEX_SMOKE_OK and nothing else."
