### PR TITLE
Add secret-surface audit and README overview image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,6 @@ jobs:
 
       - name: Public surface audit
         run: pwsh -NoProfile -File scripts/audit-public-surface.ps1
+
+      - name: Secret surface audit
+        run: pwsh -NoProfile -File scripts/audit-secret-surface.ps1

--- a/README.ja.md
+++ b/README.ja.md
@@ -6,6 +6,10 @@
 
 スマホの Telegram で bot に指示を送ると、手元の Windows PC で `codex` が動き、結果が同じチャットへ返ります。公開サーバや webhook は不要で、bot token と会話履歴は PC 側で扱います。
 
+![概要図](docs/readme-overview.svg)
+
+Telegram から指示を送り、手元の Windows PC で `codex` を動かし、結果を同じチャットに返します。
+
 ## できること
 
 - Telegram bot とローカルの Codex をつなぐ
@@ -176,11 +180,14 @@ cargo run -- service uninstall
 cargo fmt --check
 cargo test
 cargo check
+pwsh -NoProfile -File scripts/audit-public-surface.ps1
+pwsh -NoProfile -File scripts/audit-secret-surface.ps1
 ```
 
 ### 任意の実機スモーク
 
 実機スモークは任意です。CI では動きません。
+`LIVE_*` の値は、その時のシェルの環境変数だけで渡してください。追跡ファイルへは書かないでください。
 
 必須の環境変数:
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 It runs on your Windows machine, receives messages from your Telegram bot, starts `codex`, and sends the result back to the same chat. The project is designed for people who want a simple chat-based control surface without exposing a public webhook server.
 
+![Overview](docs/readme-overview.svg)
+
+Send a message on Telegram, let your Windows PC run `codex`, and get the reply back in the same chat.
+
 ## What It Does
 
 - Connects a Telegram bot to a local Codex workflow
@@ -191,11 +195,14 @@ cargo run -- service uninstall
 cargo fmt --check
 cargo test
 cargo check
+pwsh -NoProfile -File scripts/audit-public-surface.ps1
+pwsh -NoProfile -File scripts/audit-secret-surface.ps1
 ```
 
 ### Optional live smoke test
 
 The live smoke test is opt-in and does not run in CI.
+Keep the `LIVE_*` values in the current shell only. Do not write them into tracked files.
 
 Required environment variables:
 

--- a/docs/readme-overview.svg
+++ b/docs/readme-overview.svg
@@ -1,0 +1,63 @@
+<svg width="1200" height="520" viewBox="0 0 1200 520" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="520" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#F7F3EC"/>
+      <stop offset="1" stop-color="#EEF4FA"/>
+    </linearGradient>
+    <linearGradient id="card" x1="0" y1="0" x2="0" y2="1">
+      <stop stop-color="#FFFFFF"/>
+      <stop offset="1" stop-color="#F8FBFE"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="160%" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="10" stdDeviation="14" flood-color="#0F172A" flood-opacity="0.10"/>
+    </filter>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10V0Z" fill="#2F5D8C"/>
+    </marker>
+    <style>
+      .title { font: 700 36px 'Segoe UI', sans-serif; fill: #16263A; }
+      .label { font: 700 24px 'Segoe UI', sans-serif; fill: #18324D; }
+      .small { font: 700 16px 'Segoe UI', sans-serif; fill: #2F5D8C; letter-spacing: 0.08em; }
+      .mini { font: 600 14px 'Segoe UI', sans-serif; fill: #5B6B7B; }
+      .note { font: 600 13px 'Segoe UI', sans-serif; fill: #6B7B8D; }
+      .num { font: 700 20px 'Segoe UI', sans-serif; fill: #FFFFFF; }
+    </style>
+  </defs>
+
+  <rect width="1200" height="520" rx="28" fill="url(#bg)"/>
+  <text x="72" y="92" class="title">How a Telegram message runs code on your PC</text>
+
+  <rect x="84" y="184" width="210" height="212" rx="28" fill="url(#card)" filter="url(#shadow)"/>
+  <rect x="140" y="230" width="98" height="122" rx="18" fill="#6457C2"/>
+  <circle cx="189" cy="246" r="7" fill="#EDEBFF"/>
+  <rect x="154" y="274" width="70" height="14" rx="7" fill="#EDEBFF"/>
+  <rect x="154" y="300" width="70" height="14" rx="7" fill="#EDEBFF" opacity="0.82"/>
+  <rect x="154" y="326" width="44" height="14" rx="7" fill="#EDEBFF" opacity="0.64"/>
+  <text x="120" y="434" class="label">Telegram</text>
+
+  <rect x="354" y="150" width="510" height="262" rx="32" fill="url(#card)" filter="url(#shadow)"/>
+  <text x="392" y="208" class="small">WINDOWS PC</text>
+  <rect x="394" y="232" width="286" height="128" rx="28" fill="#17324D"/>
+  <text x="424" y="280" style="font: 700 28px 'Segoe UI', sans-serif; fill: #F8FAFC;">codex-channels</text>
+  <rect x="426" y="296" width="150" height="42" rx="18" fill="#FFFFFF" opacity="0.98"/>
+  <text x="460" y="324" style="font: 700 24px 'Consolas', monospace; fill: #17324D;">codex</text>
+  <text x="426" y="352" class="note" style="fill:#D8E7F7;">receives the message and runs the AI coding assistant</text>
+  <rect x="704" y="232" width="118" height="128" rx="26" fill="#FFF4E2"/>
+  <text x="726" y="286" class="label" style="font-size: 22px;">Workspace</text>
+  <text x="432" y="388" class="note">receives your message</text>
+  <text x="706" y="388" class="note">your code and files</text>
+
+  <path d="M294 290H350" stroke="#2F5D8C" stroke-width="8" stroke-linecap="round" marker-end="url(#arrow)"/>
+  <path d="M576 316H700" stroke="#2F5D8C" stroke-width="8" stroke-linecap="round" marker-end="url(#arrow)"/>
+  <path d="M470 360C448 410 360 436 248 428C220 426 206 412 196 396" stroke="#D7762C" stroke-width="8" stroke-linecap="round" fill="none" marker-end="url(#arrow)"/>
+
+  <circle cx="315" cy="244" r="17" fill="#2F5D8C"/>
+  <text x="309" y="251" class="num">1</text>
+  <text x="270" y="218" class="note">message in</text>
+  <circle cx="632" cy="280" r="17" fill="#2F5D8C"/>
+  <text x="626" y="287" class="num">2</text>
+  <text x="544" y="252" class="note">launches codex in the workspace</text>
+  <circle cx="432" cy="414" r="17" fill="#D7762C"/>
+  <text x="426" y="421" class="num">3</text>
+  <text x="460" y="420" class="note">reply back</text>
+</svg>

--- a/scripts/audit-public-surface.ps1
+++ b/scripts/audit-public-surface.ps1
@@ -32,6 +32,8 @@ $requiredTracked = @(
     'tasks/backlog.example.yaml',
     'tasks/roadmap-title-ja.example.psd1',
     'tasks/ROADMAP.example.md',
+    'docs/readme-overview.svg',
+    'scripts/audit-secret-surface.ps1',
     'scripts/planning-paths.ps1',
     'scripts/setup-planning.ps1',
     'scripts/sync-roadmap.ps1'

--- a/scripts/audit-secret-surface.ps1
+++ b/scripts/audit-secret-surface.ps1
@@ -1,0 +1,90 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+function Get-TrackedFiles {
+    $output = git ls-files
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Failed to list tracked files.'
+    }
+
+    return @($output | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+}
+
+function Test-TextFile {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    $extension = [System.IO.Path]::GetExtension($Path)
+    return $extension -notin @('.png', '.jpg', '.jpeg', '.gif', '.ico', '.pdf', '.lock')
+}
+
+function Test-PlaceholderValue {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Value
+    )
+
+    $trimmed = $Value.Trim().Trim('"', "'")
+    if ([string]::IsNullOrWhiteSpace($trimmed)) {
+        return $true
+    }
+
+    $patterns = @(
+        '^\<.+\>$',
+        '^\$\{\{.+\}\}$',
+        '^(?i)(your|example|placeholder)[-_a-z0-9 ]*$',
+        '^(?i)(chat id|sender id|bot token|workspace)$',
+        '^(?i)c:/path/to/.+'
+    )
+
+    foreach ($pattern in $patterns) {
+        if ($trimmed -match $pattern) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+$trackedFiles = Get-TrackedFiles
+$failures = New-Object System.Collections.Generic.List[string]
+$assignmentPattern = '(?i)^\s*(?<name>LIVE_[A-Z0-9_]+|TELEGRAM_BOT_TOKEN)\s*=\s*(?<value>.+?)\s*$'
+$telegramTokenPattern = '\b\d{7,12}:[A-Za-z0-9_-]{20,}\b'
+
+foreach ($path in $trackedFiles) {
+    if (-not (Test-TextFile -Path $path)) {
+        continue
+    }
+
+    $fullPath = Join-Path (Get-Location) $path
+    if (-not (Test-Path -LiteralPath $fullPath)) {
+        continue
+    }
+
+    $lines = @(Get-Content -LiteralPath $fullPath -ErrorAction Stop)
+    for ($index = 0; $index -lt $lines.Count; $index++) {
+        $line = $lines[$index]
+        if ($line -match $assignmentPattern) {
+            $name = $Matches['name']
+            $value = $Matches['value']
+            if (-not (Test-PlaceholderValue -Value $value)) {
+                $failures.Add("${path}:$($index + 1) contains a tracked assignment for $name") | Out-Null
+            }
+        }
+
+        if ($line -match $telegramTokenPattern) {
+            $failures.Add("${path}:$($index + 1) contains a Telegram bot token-like value") | Out-Null
+        }
+    }
+}
+
+if ($failures.Count -gt 0) {
+    Write-Error ("secret surface audit failed:`n- " + ($failures -join "`n- "))
+    exit 1
+}
+
+Write-Output 'secret surface audit passed'

--- a/tests/public_surface.rs
+++ b/tests/public_surface.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use anyhow::{Context, Result};
+use tempfile::tempdir;
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -9,6 +10,26 @@ fn repo_root() -> PathBuf {
 
 fn powershell() -> &'static str {
     "pwsh"
+}
+
+#[test]
+fn secret_surface_audit_script_succeeds_for_tracked_repo_state() -> Result<()> {
+    let script_path = repo_root().join("scripts").join("audit-secret-surface.ps1");
+    let output = Command::new(powershell())
+        .arg("-NoProfile")
+        .arg("-File")
+        .arg(&script_path)
+        .current_dir(repo_root())
+        .output()
+        .with_context(|| format!("failed to run {}", script_path.display()))?;
+
+    assert!(
+        output.status.success(),
+        "audit-secret-surface failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    Ok(())
 }
 
 #[test]
@@ -27,6 +48,107 @@ fn public_surface_audit_script_succeeds_for_tracked_repo_state() -> Result<()> {
         "audit-public-surface failed: {}",
         String::from_utf8_lossy(&output.stderr)
     );
+
+    Ok(())
+}
+
+#[test]
+fn secret_surface_audit_allows_placeholder_assignments() -> Result<()> {
+    let repo = tempdir()?;
+    initialize_git_repo(repo.path())?;
+    let script_path = repo.path().join("audit-secret-surface.ps1");
+    std::fs::copy(
+        repo_root().join("scripts").join("audit-secret-surface.ps1"),
+        &script_path,
+    )?;
+    std::fs::write(
+        repo.path().join("README.md"),
+        "TELEGRAM_BOT_TOKEN=<YOUR_TELEGRAM_BOT_TOKEN>\nLIVE_WORKSPACE=C:/path/to/workspace\n",
+    )?;
+    git_add(repo.path(), "README.md")?;
+
+    let output = Command::new(powershell())
+        .arg("-NoProfile")
+        .arg("-File")
+        .arg(&script_path)
+        .current_dir(repo.path())
+        .output()
+        .with_context(|| format!("failed to run {}", script_path.display()))?;
+
+    assert!(
+        output.status.success(),
+        "audit-secret-surface should allow placeholders: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    Ok(())
+}
+
+#[test]
+fn secret_surface_audit_rejects_live_assignments() -> Result<()> {
+    let repo = tempdir()?;
+    initialize_git_repo(repo.path())?;
+    let script_path = repo.path().join("audit-secret-surface.ps1");
+    std::fs::copy(
+        repo_root().join("scripts").join("audit-secret-surface.ps1"),
+        &script_path,
+    )?;
+    std::fs::write(
+        repo.path().join("README.md"),
+        concat!("LIVE_TELEGRAM_CHAT_ID", "=8642321094\n"),
+    )?;
+    git_add(repo.path(), "README.md")?;
+
+    let output = Command::new(powershell())
+        .arg("-NoProfile")
+        .arg("-File")
+        .arg(&script_path)
+        .current_dir(repo.path())
+        .output()
+        .with_context(|| format!("failed to run {}", script_path.display()))?;
+
+    assert!(
+        !output.status.success(),
+        "audit-secret-surface should reject live assignments"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("tracked assignment"));
+
+    Ok(())
+}
+
+#[test]
+fn secret_surface_audit_rejects_bot_token_like_values() -> Result<()> {
+    let repo = tempdir()?;
+    initialize_git_repo(repo.path())?;
+    let script_path = repo.path().join("audit-secret-surface.ps1");
+    std::fs::copy(
+        repo_root().join("scripts").join("audit-secret-surface.ps1"),
+        &script_path,
+    )?;
+    std::fs::write(
+        repo.path().join("README.md"),
+        concat!(
+            "Use this token: 123456789",
+            ":ABCDEFGHIJKLMNOPQRSTUV1234567890\n"
+        ),
+    )?;
+    git_add(repo.path(), "README.md")?;
+
+    let output = Command::new(powershell())
+        .arg("-NoProfile")
+        .arg("-File")
+        .arg(&script_path)
+        .current_dir(repo.path())
+        .output()
+        .with_context(|| format!("failed to run {}", script_path.display()))?;
+
+    assert!(
+        !output.status.success(),
+        "audit-secret-surface should reject token-like values"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("token-like value"));
 
     Ok(())
 }
@@ -52,6 +174,36 @@ fn live_planning_files_stay_untracked_and_examples_stay_tracked() -> Result<()> 
     assert!(!tracked.contains("tasks/backlog.yaml"));
     assert!(!tracked.contains("tasks/roadmap-title-ja.psd1"));
     assert!(!tracked.contains("docs/project/ROADMAP.md"));
+
+    Ok(())
+}
+
+fn initialize_git_repo(path: &std::path::Path) -> Result<()> {
+    let output = Command::new("git")
+        .args(["init"])
+        .current_dir(path)
+        .output()
+        .context("failed to initialize git repo")?;
+    assert!(
+        output.status.success(),
+        "git init failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    Ok(())
+}
+
+fn git_add(path: &std::path::Path, file: &str) -> Result<()> {
+    let output = Command::new("git")
+        .args(["add", file])
+        .current_dir(path)
+        .output()
+        .with_context(|| format!("failed to add {file}"))?;
+    assert!(
+        output.status.success(),
+        "git add failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add a tracked-file audit for live Telegram values and bot token-like strings
- run the new audit in CI and in the local git-guard pre-commit flow
- add a beginner-friendly README overview image reviewed with Claude Opus

## Validation
- cargo fmt --check
- cargo test
- cargo check
- pwsh -NoProfile -File scripts/audit-public-surface.ps1
- pwsh -NoProfile -File scripts/audit-secret-surface.ps1
- global pre-commit hook pass on this repo
- global pre-commit hook fail in a temp repo with a live Telegram value
