### PR TITLE
chore(release): add v0.1.11 and v0.1.12 history

### DIFF
--- a/scripts/generate-release-notes.ps1
+++ b/scripts/generate-release-notes.ps1
@@ -5,7 +5,7 @@ param(
     [string]$HistoryPath = '',
     [string]$BacklogPath = '',
     [string]$OutputPath = 'release/release-body.md',
-    [string]$Repository = 'Sora-bluesky/codex-channels',
+    [string]$Repository = 'Sora-bluesky/remotty',
     [string]$RepoRoot = ''
 )
 

--- a/scripts/release-history.psd1
+++ b/scripts/release-history.psd1
@@ -99,5 +99,23 @@
                 "Hardened approval state recovery, persistence, and operator-facing status updates."
             )
         }
+        @{
+            Version = "0.1.11"
+            Commit = "f4eb46dd2ba67ca193e54b485d6bb4d2e78ca71e"
+            Title = "Approval callback hardening"
+            Notes = @(
+                "Improved Telegram approval callback feedback, restart invalidation, and approval state tests."
+                "Kept approval history intact while making stale or repeated approval actions safer."
+            )
+        }
+        @{
+            Version = "0.1.12"
+            Commit = "927774a512b5fe3b9ace0cd378458b6a7ab2a6af"
+            Title = "Tool input approval summaries"
+            Notes = @(
+                "Sanitized tool-input approval summaries so sensitive prompt details are not forwarded to Telegram."
+                "Tightened text truncation behavior and added coverage for summary length boundaries."
+            )
+        }
     )
 }


### PR DESCRIPTION
## Summary
- add release-history entries for v0.1.11 and v0.1.12
- update generated changelog links to the renamed repository

## Verification
- cargo test --test release_automation
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1
- pwsh -NoProfile -File .\scripts\audit-secret-surface.ps1
- pwsh -NoProfile -File .\scripts\audit-doc-terminology.ps1