### PR TITLE
fix: update cargo version bump parsing

### DIFF
--- a/scripts/release-common.ps1
+++ b/scripts/release-common.ps1
@@ -244,7 +244,12 @@ function Set-CargoPackageVersion {
     )
 
     $content = Get-Content -LiteralPath $CargoTomlPath -Raw -Encoding UTF8
-    $updated = $content -replace '(?m)^version = "[^"]+"$', ('version = "' + $Version + '"')
+    $updated = [regex]::Replace(
+        $content,
+        '(?ms)(^\[package\]\s+.*?^version\s*=\s*)"[^"]+"',
+        ('$1"' + $Version + '"'),
+        1
+    )
     if ($updated -eq $content) {
         throw "Could not update version line in $CargoTomlPath"
     }

--- a/tests/release_automation.rs
+++ b/tests/release_automation.rs
@@ -234,6 +234,9 @@ fn bump_version_sync_only_updates_version_sources() -> Result<()> {
 name = "remotty"
 version = "0.1.0"
 edition = "2024"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
 "#,
     )?;
     write_file(&version_path, "0.1.0")?;
@@ -258,6 +261,7 @@ edition = "2024"
 
     let cargo_toml = fs::read_to_string(&cargo_toml_path)?;
     assert!(cargo_toml.contains("version = \"0.1.8\""));
+    assert!(cargo_toml.contains("clap = { version = \"4\", features = [\"derive\"] }"));
     assert_eq!(fs::read_to_string(&version_path)?, "0.1.8");
 
     Ok(())


### PR DESCRIPTION
## Summary
- update the release helper to replace only the `[package]` version in `Cargo.toml`
- handle Windows line endings in `Cargo.toml`
- add coverage that dependency version constraints are preserved

## Verification
- `cargo fmt -- --check`
- `cargo test --test release_automation`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File .\scripts\audit-doc-terminology.ps1`
- `pwsh -NoProfile -File .\scripts\audit-secret-surface.ps1`