### PR TITLE
fix: branch before release version edits

### DIFF
--- a/scripts/bump-version.ps1
+++ b/scripts/bump-version.ps1
@@ -42,6 +42,18 @@ if (-not $SyncOnly) {
         & $auditPublicSurfaceScript | Out-Null
         & $auditDocTerminologyScript | Out-Null
         & $auditSecretSurfaceScript | Out-Null
+
+        if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+            throw "GitHub CLI (gh) is required for release."
+        }
+
+        $status = git status --porcelain 2>&1
+        if ($status) {
+            throw "Working tree is not clean. Commit or stash changes before releasing."
+        }
+
+        $branch = "release/$tag"
+        git switch -c $branch | Out-Null
     } finally {
         Pop-Location
     }
@@ -57,18 +69,6 @@ if ($SyncOnly) {
 
 Push-Location $resolvedRepoRoot
 try {
-    if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
-        throw "GitHub CLI (gh) is required for release."
-    }
-
-    $status = git status --porcelain 2>&1
-    if ($status) {
-        throw "Working tree is not clean. Commit or stash changes before releasing."
-    }
-
-    $branch = "release/$tag"
-    git switch -c $branch | Out-Null
-
     git add VERSION Cargo.toml
     git commit -m "chore: bump version to $normalizedVersion" | Out-Null
     git push -u origin $branch | Out-Null


### PR DESCRIPTION
## Summary
- make the release script create the release branch before editing version files
- keep the clean-tree check meaningful before generated release edits are written

## Verification
- `cargo fmt -- --check`
- `cargo test --test release_automation`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File .\scripts\audit-doc-terminology.ps1`
- `pwsh -NoProfile -File .\scripts\audit-secret-surface.ps1`