### PR TITLE
fix: stop release on native command failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "remotty"
-version = "0.1.8"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/scripts/bump-version.ps1
+++ b/scripts/bump-version.ps1
@@ -23,6 +23,17 @@ $backlogPath = Resolve-RemottyExternalPlanningFilePath -EnvironmentVariable 'REM
 $roadmapPath = Resolve-RemottyExternalPlanningFilePath -EnvironmentVariable 'REMOTTY_ROADMAP_PATH' -DefaultFileName 'ROADMAP.md'
 $titlePath = Resolve-RemottyExternalPlanningFilePath -EnvironmentVariable 'REMOTTY_ROADMAP_TITLE_JA_PATH' -DefaultFileName 'roadmap-title-ja.psd1'
 
+function Assert-NativeSuccess {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Command
+    )
+
+    if ($LASTEXITCODE -ne 0) {
+        throw ("{0} failed with exit code {1}" -f $Command, $LASTEXITCODE)
+    }
+}
+
 if ([string]::IsNullOrWhiteSpace($Version)) {
     if (-not (Test-Path -LiteralPath $versionFile)) {
         throw "VERSION file not found: $versionFile"
@@ -54,6 +65,7 @@ if (-not $SyncOnly) {
 
         $branch = "release/$tag"
         git switch -c $branch | Out-Null
+        Assert-NativeSuccess "git switch -c $branch"
     } finally {
         Pop-Location
     }
@@ -70,22 +82,33 @@ if ($SyncOnly) {
 Push-Location $resolvedRepoRoot
 try {
     git add VERSION Cargo.toml
+    Assert-NativeSuccess "git add VERSION Cargo.toml"
     git commit -m "chore: bump version to $normalizedVersion" | Out-Null
+    Assert-NativeSuccess "git commit"
     git push -u origin $branch | Out-Null
+    Assert-NativeSuccess "git push -u origin $branch"
 
     $prUrl = gh pr create --base main --head $branch --title "chore: bump version to $normalizedVersion" --body "Automated release via `scripts/bump-version.ps1 -Version $normalizedVersion`."
+    Assert-NativeSuccess "gh pr create"
     $prNumber = if ($prUrl -match '/(\d+)$') { $Matches[1] } else { $prUrl }
     gh pr checks $prNumber --watch | Out-Null
+    Assert-NativeSuccess "gh pr checks $prNumber --watch"
     gh pr merge $prNumber --merge --delete-branch | Out-Null
+    Assert-NativeSuccess "gh pr merge $prNumber"
 
     git switch main | Out-Null
+    Assert-NativeSuccess "git switch main"
     git pull --ff-only origin main | Out-Null
+    Assert-NativeSuccess "git pull --ff-only origin main"
     git tag $tag
+    Assert-NativeSuccess "git tag $tag"
     git push origin $tag | Out-Null
+    Assert-NativeSuccess "git push origin $tag"
 
     $notesPath = Join-Path $resolvedRepoRoot 'release\release-body.md'
     & $generateNotesScript -Version $normalizedVersion -OutputPath $notesPath -RepoRoot $resolvedRepoRoot
     gh release create $tag --title $tag --notes-file $notesPath --verify-tag --latest | Out-Null
+    Assert-NativeSuccess "gh release create $tag"
 
     $updatedTaskIds = Update-ReleaseBacklogStatus -BacklogPath $backlogPath -Version $normalizedVersion
     if ($updatedTaskIds.Count -gt 0) {

--- a/tests/release_automation.rs
+++ b/tests/release_automation.rs
@@ -374,6 +374,41 @@ fn bump_version_runs_public_audits_before_release_workflow() -> Result<()> {
 }
 
 #[test]
+fn bump_version_checks_native_release_command_failures() -> Result<()> {
+    let script = fs::read_to_string(repo_root().join("scripts").join("bump-version.ps1"))?;
+
+    for command in [
+        "git switch -c $branch",
+        "git add VERSION Cargo.toml",
+        "git commit",
+        "git push -u origin $branch",
+        "gh pr create",
+        "gh pr checks $prNumber --watch",
+        "gh pr merge $prNumber",
+        "git switch main",
+        "git pull --ff-only origin main",
+        "git tag $tag",
+        "git push origin $tag",
+        "gh release create $tag",
+    ] {
+        let command_position = script
+            .find(command)
+            .with_context(|| format!("missing native command: {command}"))?;
+        let assertion = format!("Assert-NativeSuccess \"{command}\"");
+        let assertion_position = script
+            .find(&assertion)
+            .with_context(|| format!("missing native success assertion: {assertion}"))?;
+
+        assert!(
+            command_position < assertion_position,
+            "success assertion should follow native command: {command}"
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
 fn release_preflight_allows_missing_title_map_when_backlog_exists() -> Result<()> {
     let temp = TempDir::new()?;
     let backlog_path = temp.path().join("backlog.yaml");


### PR DESCRIPTION
## Summary
- stop the release script when git or gh commands return nonzero exit codes
- cover the release script guard with release automation tests
- update Cargo.lock to the current package version

## Verification
- cargo fmt -- --check
- cargo test
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1
- pwsh -NoProfile -File .\scripts\audit-secret-surface.ps1
- pwsh -NoProfile -File .\scripts\audit-doc-terminology.ps1