### PR TITLE
ci: add gitleaks secret scan

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,30 @@
+name: Gitleaks
+
+on:
+  push:
+    branches:
+      - main
+      - feature/**
+      - codex/**
+      - release/**
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  scan:
+    name: scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Gitleaks scan
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -238,6 +238,14 @@ checks_profile = "default"
 - Runtime state is ignored by `.gitignore`
 - Local secret-scanning hooks are recommended before commit and push
 
+Secret checks are intentionally layered:
+
+| Layer | Implementation | Scope |
+| --- | --- | --- |
+| pre-commit | Global `~/.git-hooks/pre-commit` with git-guard-style regex checks | staged diff |
+| CI | `.github/workflows/gitleaks.yml` with the Gitleaks GitHub Action | push and pull request changes |
+| Manual history scan | `gitleaks git --log-opts=--all --redact --verbose .` | full git history |
+
 ## CLI Compatibility
 
 The standalone Rust CLI still works and remains the compatibility path while the plugin surface matures.

--- a/tests/public_surface.rs
+++ b/tests/public_surface.rs
@@ -33,6 +33,24 @@ fn secret_surface_audit_script_succeeds_for_tracked_repo_state() -> Result<()> {
 }
 
 #[test]
+fn gitleaks_workflow_keeps_ci_secret_scan_enabled() -> Result<()> {
+    let workflow = std::fs::read_to_string(
+        repo_root()
+            .join(".github")
+            .join("workflows")
+            .join("gitleaks.yml"),
+    )?;
+
+    assert!(workflow.contains("gitleaks/gitleaks-action@v2"));
+    assert!(workflow.contains("fetch-depth: 0"));
+    assert!(workflow.contains("pull_request:"));
+    assert!(workflow.contains("push:"));
+    assert!(workflow.contains("GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}"));
+
+    Ok(())
+}
+
+#[test]
 fn public_surface_audit_script_succeeds_for_tracked_repo_state() -> Result<()> {
     let script_path = repo_root().join("scripts").join("audit-public-surface.ps1");
     let output = Command::new(powershell())


### PR DESCRIPTION
## Summary
- add a dedicated Gitleaks GitHub Actions workflow
- document the secret scanning layers in README
- add a public-surface test that keeps the Gitleaks workflow enabled

## Verification
- cargo fmt -- --check
- cargo test --test public_surface
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1
- pwsh -NoProfile -File .\scripts\audit-secret-surface.ps1
- pwsh -NoProfile -File .\scripts\audit-doc-terminology.ps1
- gitleaks git --log-opts=--all --redact --verbose .