### PR TITLE
feat: centralize telegram polling guard

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -13,10 +13,9 @@ use crate::store::{
 };
 use crate::telegram::{
     IncomingMessage, SavedTelegramAttachment, TelegramAttachmentKind, TelegramClient,
-    TelegramControlCommand,
+    TelegramControlCommand, TelegramPoller,
 };
 use crate::telegram_cli::send_access_pair_code;
-use crate::telegram_poller_guard::TelegramPollerGuard;
 use crate::windows_secret::load_secret;
 
 const MAX_COMPLETION_REPAIR_TURNS: usize = 2;
@@ -146,8 +145,7 @@ pub async fn run_with_shutdown(config: Config, shutdown: CancellationToken) -> R
         config.telegram.api_base_url.clone(),
         config.telegram.file_base_url.clone(),
     );
-    let bot = telegram.get_me().await?;
-    let _poller_guard = TelegramPollerGuard::acquire(bot.id)?;
+    let poller = TelegramPoller::acquire(telegram.clone()).await?;
     let store = Store::open(&config.storage.db_path)?;
     seed_admin_senders(&store, &config.telegram.admin_sender_ids)?;
     let codex = CodexRunner::new(config.codex.clone());
@@ -161,7 +159,7 @@ pub async fn run_with_shutdown(config: Config, shutdown: CancellationToken) -> R
                 info!("shutdown requested");
                 break;
             }
-            result = telegram.get_updates(offset, config.service.poll_timeout_sec) => result?,
+            result = poller.get_updates(offset, config.service.poll_timeout_sec) => result?,
         };
         for update in updates {
             offset = Some(update.update_id + 1);

--- a/src/live_smoke.rs
+++ b/src/live_smoke.rs
@@ -12,8 +12,7 @@ use tokio::time::sleep;
 
 use crate::config::Config;
 use crate::store::Store;
-use crate::telegram::TelegramClient;
-use crate::telegram_poller_guard::TelegramPollerGuard;
+use crate::telegram::{TelegramClient, TelegramPoller};
 use crate::windows_secret::load_secret;
 
 const LIVE_WORKSPACE_MARKER: &str = ".remotty-live-smoke-ok";
@@ -45,10 +44,9 @@ pub async fn run_smoke(config_path: impl AsRef<Path>, scenario: SmokeScenario) -
         base_config.telegram.api_base_url.clone(),
         base_config.telegram.file_base_url.clone(),
     );
-    let bot = telegram.get_me().await?;
-    let guard = TelegramPollerGuard::acquire(bot.id)?;
+    let poller = TelegramPoller::acquire(telegram.clone()).await?;
     ensure_polling_mode(&telegram).await?;
-    drop(guard);
+    drop(poller);
 
     let temp = tempdir()?;
     let config_path = write_live_config(temp.path(), &base_config, &live)?;

--- a/src/telegram.rs
+++ b/src/telegram.rs
@@ -8,6 +8,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use crate::telegram_poller_guard::TelegramPollerGuard;
+
 #[derive(Clone)]
 pub struct TelegramClient {
     http: Client,
@@ -198,6 +200,74 @@ pub struct TelegramWebhookInfo {
     pub url: String,
 }
 
+pub struct TelegramPoller {
+    client: TelegramClient,
+    bot: TelegramBotInfo,
+    _guard: TelegramPollerGuard,
+}
+
+impl TelegramPoller {
+    pub async fn acquire(client: TelegramClient) -> Result<Self> {
+        let bot = client.get_me().await?;
+        let guard = TelegramPollerGuard::acquire(bot.id)?;
+        Ok(Self {
+            client,
+            bot,
+            _guard: guard,
+        })
+    }
+
+    pub fn bot(&self) -> &TelegramBotInfo {
+        &self.bot
+    }
+
+    pub async fn get_updates(
+        &self,
+        offset: Option<i64>,
+        timeout_sec: u64,
+    ) -> Result<Vec<IncomingMessage>> {
+        let response = self
+            .client
+            .request_updates(
+                offset,
+                timeout_sec,
+                &["message", "edited_message", "callback_query"],
+            )
+            .await?;
+        parse_updates(response)
+    }
+
+    pub async fn get_pairing_updates(
+        &self,
+        offset: Option<i64>,
+        timeout_sec: u64,
+    ) -> Result<Vec<PairingUpdate>> {
+        let response = self
+            .client
+            .request_updates(offset, timeout_sec, &["message"])
+            .await?;
+        parse_pairing_updates(response)
+    }
+
+    pub async fn drain_pending_updates(&self) -> Result<()> {
+        let mut offset = None;
+        loop {
+            let response = self
+                .client
+                .request_updates(offset, 0, &["message", "edited_message", "callback_query"])
+                .await?;
+            if !response.ok {
+                bail!("telegram getUpdates returned ok=false");
+            }
+            let Some(last_update_id) = response.result.iter().map(|update| update.update_id).max()
+            else {
+                return Ok(());
+            };
+            offset = Some(last_update_id + 1);
+        }
+    }
+}
+
 impl TelegramClient {
     pub fn new(token: String) -> Self {
         Self::with_base_urls(
@@ -275,49 +345,6 @@ impl TelegramClient {
             bail!("telegram deleteWebhook returned ok=false");
         }
         Ok(())
-    }
-
-    pub async fn get_updates(
-        &self,
-        offset: Option<i64>,
-        timeout_sec: u64,
-    ) -> Result<Vec<IncomingMessage>> {
-        let response = self
-            .request_updates(
-                offset,
-                timeout_sec,
-                &["message", "edited_message", "callback_query"],
-            )
-            .await?;
-        parse_updates(response)
-    }
-
-    pub async fn get_pairing_updates(
-        &self,
-        offset: Option<i64>,
-        timeout_sec: u64,
-    ) -> Result<Vec<PairingUpdate>> {
-        let response = self
-            .request_updates(offset, timeout_sec, &["message"])
-            .await?;
-        parse_pairing_updates(response)
-    }
-
-    pub async fn drain_pending_updates(&self) -> Result<()> {
-        let mut offset = None;
-        loop {
-            let response = self
-                .request_updates(offset, 0, &["message", "edited_message", "callback_query"])
-                .await?;
-            if !response.ok {
-                bail!("telegram getUpdates returned ok=false");
-            }
-            let Some(last_update_id) = response.result.iter().map(|update| update.update_id).max()
-            else {
-                return Ok(());
-            };
-            offset = Some(last_update_id + 1);
-        }
     }
 
     pub async fn send_message(&self, chat_id: i64, text: &str) -> Result<SendMessageResult> {

--- a/src/telegram_cli.rs
+++ b/src/telegram_cli.rs
@@ -8,8 +8,7 @@ use rpassword as hidden_input;
 
 use crate::config::Config;
 use crate::store::{AuthorizedSender, PendingAccessPairCode, Store};
-use crate::telegram::{PairingUpdate, TelegramClient};
-use crate::telegram_poller_guard::TelegramPollerGuard;
+use crate::telegram::{PairingUpdate, TelegramClient, TelegramPoller};
 use crate::windows_secret::{load_secret, store_secret};
 
 const DEFAULT_SECRET_REF: &str = "remotty-telegram-bot";
@@ -93,11 +92,10 @@ async fn pair_with_code_until(
         config.telegram.file_base_url.clone(),
     );
     ensure_polling_mode_for_pairing(&telegram).await?;
-    let bot = telegram.get_me().await?;
-    let _poller_guard = TelegramPollerGuard::acquire(bot.id)?;
+    let poller = TelegramPoller::acquire(telegram).await?;
     let candidate = wait_for_pair_candidate(
-        &telegram,
-        bot.username.as_deref(),
+        &poller,
+        poller.bot().username.as_deref(),
         pair_code,
         issued_after_s,
         deadline_s,
@@ -367,7 +365,7 @@ fn ensure_private_pair_candidate(candidate: &PairCandidate) -> Result<()> {
 }
 
 async fn wait_for_pair_candidate(
-    telegram: &TelegramClient,
+    poller: &TelegramPoller,
     bot_username: Option<&str>,
     expected_code: &str,
     issued_after_s: i64,
@@ -376,7 +374,7 @@ async fn wait_for_pair_candidate(
     let mut offset = None;
 
     while Utc::now().timestamp() <= deadline_s {
-        let updates = telegram.get_pairing_updates(offset, 5).await?;
+        let updates = poller.get_pairing_updates(offset, 5).await?;
         if let Some(last_update_id) = updates.last().map(|update| update.update_id) {
             offset = Some(last_update_id + 1);
         }

--- a/tests/telegram_fake_server.rs
+++ b/tests/telegram_fake_server.rs
@@ -6,6 +6,7 @@ use chrono::Utc;
 use remotty::store::{PendingAccessPairCode, Store};
 use remotty::telegram::{
     TelegramAttachment, TelegramAttachmentKind, TelegramClient, TelegramControlCommand,
+    TelegramPoller,
 };
 use remotty::telegram_cli::{access_pair, pair_with_code};
 use serial_test::serial;
@@ -13,6 +14,7 @@ use std::fs;
 use tempfile::tempdir;
 
 #[tokio::test]
+#[serial]
 async fn telegram_client_routes_updates_and_callback_operations_to_fake_server() -> Result<()> {
     let server = fake_telegram::FakeTelegramServer::start("test-token").await?;
     server
@@ -32,7 +34,8 @@ async fn telegram_client_routes_updates_and_callback_operations_to_fake_server()
     assert_eq!(bot.id, 77_000);
     assert_eq!(bot.username.as_deref(), Some("remotty_test_bot"));
 
-    let updates = client.get_updates(None, 0).await?;
+    let poller = TelegramPoller::acquire(client.clone()).await?;
+    let updates = poller.get_updates(None, 0).await?;
     assert_eq!(updates.len(), 2);
     assert_eq!(updates[0].text, "hello from fake telegram");
     assert_eq!(
@@ -47,6 +50,7 @@ async fn telegram_client_routes_updates_and_callback_operations_to_fake_server()
     client
         .answer_callback_query("callback-2", Some("processed"))
         .await?;
+    drop(poller);
 
     let sent = server.sent_messages().await;
     assert_eq!(sent.len(), 1);
@@ -68,6 +72,7 @@ async fn telegram_client_routes_updates_and_callback_operations_to_fake_server()
 }
 
 #[tokio::test]
+#[serial]
 async fn telegram_client_handles_webhook_and_attachment_download_against_fake_server() -> Result<()>
 {
     let server = fake_telegram::FakeTelegramServer::start("test-token").await?;
@@ -91,8 +96,10 @@ async fn telegram_client_handles_webhook_and_attachment_download_against_fake_se
     assert_eq!(delete_calls.len(), 1);
     assert!(!delete_calls[0].drop_pending_updates);
 
-    let pairing = client.get_pairing_updates(None, 0).await?;
+    let poller = TelegramPoller::acquire(client.clone()).await?;
+    let pairing = poller.get_pairing_updates(None, 0).await?;
     assert!(pairing.is_empty());
+    drop(poller);
 
     let saved = client
         .save_attachment(


### PR DESCRIPTION
## Summary
- add TelegramPoller to combine getMe, single-bot mutex acquisition, and getUpdates reads
- route bridge, legacy pairing, and live smoke guard checks through the poller path
- update fake Telegram integration tests to exercise the guarded poller path

## Verification
- cargo fmt -- --check
- cargo test
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1
- pwsh -NoProfile -File .\scripts\audit-secret-surface.ps1
- pwsh -NoProfile -File .\scripts\audit-doc-terminology.ps1
- gitleaks git --log-opts=--all --redact --verbose .