### PR TITLE
fix: keep release backlog updates countable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "remotty"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/scripts/bump-version.ps1
+++ b/scripts/bump-version.ps1
@@ -110,7 +110,7 @@ try {
     gh release create $tag --title $tag --notes-file $notesPath --verify-tag --latest | Out-Null
     Assert-NativeSuccess "gh release create $tag"
 
-    $updatedTaskIds = Update-ReleaseBacklogStatus -BacklogPath $backlogPath -Version $normalizedVersion
+    $updatedTaskIds = @(Update-ReleaseBacklogStatus -BacklogPath $backlogPath -Version $normalizedVersion)
     if ($updatedTaskIds.Count -gt 0) {
         & $syncRoadmapScript -BacklogPath $backlogPath -RoadmapPath $roadmapPath -RoadmapTitleJaPath $titlePath | Out-Null
     }

--- a/tests/release_automation.rs
+++ b/tests/release_automation.rs
@@ -409,6 +409,21 @@ fn bump_version_checks_native_release_command_failures() -> Result<()> {
 }
 
 #[test]
+fn bump_version_keeps_empty_backlog_updates_countable() -> Result<()> {
+    let script = fs::read_to_string(repo_root().join("scripts").join("bump-version.ps1"))?;
+
+    assert!(
+        script.contains(
+            "$updatedTaskIds = @(Update-ReleaseBacklogStatus -BacklogPath $backlogPath -Version $normalizedVersion)"
+        ),
+        "bump-version should keep empty backlog update results as an array"
+    );
+    assert!(script.contains("if ($updatedTaskIds.Count -gt 0)"));
+
+    Ok(())
+}
+
+#[test]
 fn release_preflight_allows_missing_title_map_when_backlog_exists() -> Result<()> {
     let temp = TempDir::new()?;
     let backlog_path = temp.path().join("backlog.yaml");


### PR DESCRIPTION
## Summary
- keep empty release backlog update results as an array under PowerShell strict mode
- add a release automation test for the empty-result case
- update Cargo.lock to the released package version

## Verification
- cargo fmt -- --check
- cargo test --test release_automation
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1
- pwsh -NoProfile -File .\scripts\audit-secret-surface.ps1
- pwsh -NoProfile -File .\scripts\audit-doc-terminology.ps1
- gitleaks git --log-opts=--all --redact --verbose .