### PR TITLE
fix: update cargo lock during release bump

### DIFF
--- a/scripts/bump-version.ps1
+++ b/scripts/bump-version.ps1
@@ -13,6 +13,7 @@ $ErrorActionPreference = 'Stop'
 $resolvedRepoRoot = Resolve-RemottyRepoRoot -RepoRoot $RepoRoot
 $versionFile = Join-Path $resolvedRepoRoot 'VERSION'
 $cargoTomlPath = Join-Path $resolvedRepoRoot 'Cargo.toml'
+$cargoLockPath = Join-Path $resolvedRepoRoot 'Cargo.lock'
 $syncRoadmapScript = Join-Path $PSScriptRoot 'sync-roadmap.ps1'
 $generateNotesScript = Join-Path $PSScriptRoot 'generate-release-notes.ps1'
 $validatePlanningScript = Join-Path $PSScriptRoot 'validate-planning.ps1'
@@ -73,6 +74,7 @@ if (-not $SyncOnly) {
 
 [System.IO.File]::WriteAllText($versionFile, $normalizedVersion, [System.Text.UTF8Encoding]::new($false))
 Set-CargoPackageVersion -CargoTomlPath $cargoTomlPath -Version $normalizedVersion
+Set-CargoLockPackageVersion -CargoLockPath $cargoLockPath -PackageName 'remotty' -Version $normalizedVersion
 
 if ($SyncOnly) {
     Write-Output ("Synced version files to {0}" -f $normalizedVersion)
@@ -81,8 +83,8 @@ if ($SyncOnly) {
 
 Push-Location $resolvedRepoRoot
 try {
-    git add VERSION Cargo.toml
-    Assert-NativeSuccess "git add VERSION Cargo.toml"
+    git add VERSION Cargo.toml Cargo.lock
+    Assert-NativeSuccess "git add VERSION Cargo.toml Cargo.lock"
     git commit -m "chore: bump version to $normalizedVersion" | Out-Null
     Assert-NativeSuccess "git commit"
     git push -u origin $branch | Out-Null

--- a/scripts/release-common.ps1
+++ b/scripts/release-common.ps1
@@ -54,6 +54,41 @@ function Get-ReleaseTag {
     return "v$(Normalize-ReleaseVersion -Version $Version)"
 }
 
+function Set-CargoLockPackageVersion {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$CargoLockPath,
+        [Parameter(Mandatory = $true)]
+        [string]$PackageName,
+        [Parameter(Mandatory = $true)]
+        [string]$Version
+    )
+
+    if (-not (Test-Path -LiteralPath $CargoLockPath)) {
+        return
+    }
+
+    $content = Get-Content -LiteralPath $CargoLockPath -Raw -Encoding UTF8
+    $normalized = $content -replace "`r`n", "`n"
+    $escapedName = [regex]::Escape($PackageName)
+    $pattern = "(?ms)(\[\[package\]\]\nname = `"$escapedName`"\nversion = `")([^`"]+)(`")"
+    $updated = [regex]::Replace(
+        $normalized,
+        $pattern,
+        {
+            param($match)
+            return $match.Groups[1].Value + $Version + $match.Groups[3].Value
+        },
+        1
+    )
+
+    if ($updated -eq $normalized) {
+        throw "Package '$PackageName' not found in Cargo.lock: $CargoLockPath"
+    }
+
+    [System.IO.File]::WriteAllText($CargoLockPath, $updated, [System.Text.UTF8Encoding]::new($false))
+}
+
 function ConvertFrom-YamlScalar {
     param(
         [AllowNull()]

--- a/tests/release_automation.rs
+++ b/tests/release_automation.rs
@@ -226,6 +226,7 @@ fn generate_release_notes_uses_backlog_env_override_when_no_argument_is_passed()
 fn bump_version_sync_only_updates_version_sources() -> Result<()> {
     let temp = TempDir::new()?;
     let cargo_toml_path = temp.path().join("Cargo.toml");
+    let cargo_lock_path = temp.path().join("Cargo.lock");
     let version_path = temp.path().join("VERSION");
 
     write_file(
@@ -237,6 +238,20 @@ edition = "2024"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+"#,
+    )?;
+    write_file(
+        &cargo_lock_path,
+        r#"[[package]]
+name = "remotty"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.0"
 "#,
     )?;
     write_file(&version_path, "0.1.0")?;
@@ -262,6 +277,9 @@ clap = { version = "4", features = ["derive"] }
     let cargo_toml = fs::read_to_string(&cargo_toml_path)?;
     assert!(cargo_toml.contains("version = \"0.1.8\""));
     assert!(cargo_toml.contains("clap = { version = \"4\", features = [\"derive\"] }"));
+    let cargo_lock = fs::read_to_string(&cargo_lock_path)?;
+    assert!(cargo_lock.contains("name = \"remotty\"\nversion = \"0.1.8\""));
+    assert!(cargo_lock.contains("name = \"clap\"\nversion = \"4.5.0\""));
     assert_eq!(fs::read_to_string(&version_path)?, "0.1.8");
 
     Ok(())
@@ -379,7 +397,7 @@ fn bump_version_checks_native_release_command_failures() -> Result<()> {
 
     for command in [
         "git switch -c $branch",
-        "git add VERSION Cargo.toml",
+        "git add VERSION Cargo.toml Cargo.lock",
         "git commit",
         "git push -u origin $branch",
         "gh pr create",


### PR DESCRIPTION
## Summary
- update the root package entry in Cargo.lock during release version bumps
- stage Cargo.lock with VERSION and Cargo.toml in the release commit
- cover the Cargo.lock update path in release automation tests

## Verification
- cargo fmt -- --check
- cargo test --test release_automation
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1
- pwsh -NoProfile -File .\scripts\audit-secret-surface.ps1
- pwsh -NoProfile -File .\scripts\audit-doc-terminology.ps1
- gitleaks git --log-opts=--all --redact --verbose .