### PR TITLE
docs: add v0.1.14 release history

### DIFF
--- a/scripts/release-history.psd1
+++ b/scripts/release-history.psd1
@@ -128,5 +128,16 @@
                 "Hardened release and public-surface audit automation for Windows output handling."
             )
         }
+        @{
+            Version = "0.1.14"
+            Commit = "adf7640e8692ac23c99cbdcbf57abee4d10f55be"
+            Title = "Guarded Telegram polling"
+            Notes = @(
+                "Centralized Telegram update reads behind a guarded poller that resolves bot identity before polling."
+                "Routed bridge runtime, legacy pairing, and live smoke guard checks through the same poller path."
+                "Added CI-backed Gitleaks scanning and documented the layered secret checks."
+                "Hardened release automation so Cargo.lock and empty planning updates are handled consistently."
+            )
+        }
     )
 }


### PR DESCRIPTION
## Summary
- add the v0.1.14 entry to release history
- document the guarded Telegram polling release notes

## Verification
- cargo test --test release_automation
- pwsh -NoProfile -File .\scripts\audit-doc-terminology.ps1
- pwsh -NoProfile -File .\scripts\generate-release-notes.ps1 -Version 0.1.14 -OutputPath <temp> -RepoRoot <repo>
- gitleaks git --log-opts=--all --redact --verbose .