### PR TITLE
docs: add v0.1.15 release history

### DIFF
--- a/scripts/release-history.psd1
+++ b/scripts/release-history.psd1
@@ -139,5 +139,16 @@
                 "Hardened release automation so Cargo.lock and empty planning updates are handled consistently."
             )
         }
+        @{
+            Version = "0.1.15"
+            Commit = "678693b2c67fd3a443e36ccf656780a52844570c"
+            Title = "npm installation package"
+            Notes = @(
+                "Added an npm package entry point that installs the matching Windows release binary."
+                "Included the local Codex plugin, bridge starter config, and npm installer in the package tarball."
+                "Attached both a stable remotty.tgz package and a versioned package tarball to GitHub Releases."
+                "Updated public setup docs to use the GitHub Release package before npm registry publishing."
+            )
+        }
     )
 }


### PR DESCRIPTION
## Summary
- add v0.1.15 release history for npm package installation
- let release note generation produce specific v0.1.15 highlights

## Verification
- cargo test --test release_automation
- pwsh -NoProfile -File .\scripts\audit-doc-terminology.ps1
- gitleaks git --log-opts=--all --redact --verbose .