### PR TITLE
docs: add v0.1.19 release history

### DIFF
--- a/scripts/release-history.psd1
+++ b/scripts/release-history.psd1
@@ -183,5 +183,16 @@
                 "Published the quickstart release with both stable and versioned npm tarballs attached to GitHub Releases."
             )
         }
+        @{
+            Version = "0.1.19"
+            Commit = "213a8222ac049f067ffeaa913b0e8422fa45a9c3"
+            Title = "Local fakechat demo"
+            Notes = @(
+                "Added ``remotty demo fakechat`` for a localhost browser chat UI that calls the local Codex CLI without Telegram credentials."
+                "Added English and Japanese fakechat demo docs and linked them from both README files."
+                "Added the ``/remotty-fakechat-demo`` plugin command guide."
+                "Included ``docs/`` in the npm package so quickstart and demo links work after installation."
+            )
+        }
     )
 }


### PR DESCRIPTION
## Summary
- add release-history entry for v0.1.19
- update the published v0.1.19 GitHub Release notes with concrete highlights

## Checks
- cargo test --test release_automation
- pwsh -NoProfile -File .\\scripts\\audit-doc-terminology.ps1
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1
- pwsh -NoProfile -File .\\scripts\\audit-secret-surface.ps1
- git diff --check
- gitleaks git --log-opts=--all --redact --verbose .