### PR TITLE
fix: publish npm release tarball path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,4 +101,4 @@ jobs:
         if: ${{ env.NPM_TOKEN != '' }}
         env:
           NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
-        run: npm publish release/remotty-*.tgz --access public
+        run: npm publish ./release/remotty-*.tgz --access public

--- a/tests/public_surface.rs
+++ b/tests/public_surface.rs
@@ -76,7 +76,7 @@ fn npm_package_keeps_binary_install_contract() -> Result<()> {
     assert!(release_workflow.contains("npm pack --pack-destination release"));
     assert!(release_workflow.contains("cp release/remotty-*.tgz release/remotty.tgz"));
     assert!(release_workflow.contains("NPM_TOKEN: ${{ secrets.NPM_TOKEN }}"));
-    assert!(release_workflow.contains("npm publish release/remotty-*.tgz --access public"));
+    assert!(release_workflow.contains("npm publish ./release/remotty-*.tgz --access public"));
     assert!(readme.contains("releases/latest/download/remotty.tgz"));
     assert!(readme.contains("NPM_TOKEN"));
     assert!(readme.contains("npm publish .\\release\\remotty.tgz"));


### PR DESCRIPTION
## Summary
- fix the npm publish step so the release tarball is treated as a local file path
- keep the public surface test aligned with the publish command

## Checks
- cargo test npm_package_keeps_binary_install_contract --test public_surface
- pwsh -NoProfile -File .\scripts\audit-public-surface.ps1
- pwsh -NoProfile -File .\scripts\audit-secret-surface.ps1
- pwsh -NoProfile -File .\scripts\audit-doc-terminology.ps1
- gitleaks git --log-opts=--all --redact --verbose .