### PR TITLE
docs: simplify npm install steps

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -64,37 +64,33 @@ Telegram の設定を一本道で進めたい場合は、専用の [Telegram ク
 
 ### 1. `remotty` を入れる
 
-`npm` から入れます。
+- **1. `npm` からインストールします。**
 
 ```powershell
 npm install -g remotty
-$remottyRoot = Join-Path (npm root -g) "remotty"
-Set-Location $remottyRoot
-$configDir = Join-Path $env:APPDATA "remotty"
-New-Item -ItemType Directory -Force -Path $configDir | Out-Null
-Copy-Item -Force .\bridge.toml (Join-Path $configDir "bridge.toml")
-$configPath = Join-Path $configDir "bridge.toml"
 ```
 
-このパッケージは `remotty` コマンドを入れます。
-同じ版の GitHub Release から Windows 用バイナリも取得します。
-`npm root -g` は、グローバル npm パッケージの保存先を返します。
-次の2行で、同梱の `bridge.toml` を `Copy-Item` で読める場所へ移動します。
-手順3では、同じフォルダを Codex App から開きます。
-残りの行は、設定の土台を `%APPDATA%\remotty\bridge.toml` へコピーします。
-設定と実行時の状態を、グローバル npm パッケージフォルダに置かないためです。
+このコマンドで `remotty` が入り、同じ版の Windows 用バイナリも取得されます。
 
-GitHub Release の tarball から直接入れたい場合は、次を使います。
+- **2. インストール先のフォルダへ移動します。**
 
 ```powershell
-npm install -g https://github.com/Sora-bluesky/remotty/releases/latest/download/remotty.tgz
 $remottyRoot = Join-Path (npm root -g) "remotty"
 Set-Location $remottyRoot
+```
+
+あとでローカルプラグインを入れる時に、この `$remottyRoot` フォルダを Codex App から開きます。
+
+- **3. 設定ファイルをユーザー用の設定フォルダへコピーします。**
+
+```powershell
 $configDir = Join-Path $env:APPDATA "remotty"
 New-Item -ItemType Directory -Force -Path $configDir | Out-Null
 Copy-Item -Force .\bridge.toml (Join-Path $configDir "bridge.toml")
 $configPath = Join-Path $configDir "bridge.toml"
 ```
+
+設定と実行時の状態は、グローバル npm パッケージフォルダではなく `%APPDATA%\remotty` に置かれます。
 
 ソースから作業したい場合は、[開発者向け情報](docs/development.ja.md) を参照してください。
 

--- a/README.md
+++ b/README.md
@@ -65,33 +65,33 @@ It also explains how `remotty` differs from Codex Remote connections.
 
 ### 1. Install `remotty`
 
-Install from npm:
+- **1. Install from npm.**
 
 ```powershell
 npm install -g remotty
-$remottyRoot = Join-Path (npm root -g) "remotty"
-Set-Location $remottyRoot
-$configDir = Join-Path $env:APPDATA "remotty"
-New-Item -ItemType Directory -Force -Path $configDir | Out-Null
-Copy-Item -Force .\bridge.toml (Join-Path $configDir "bridge.toml")
-$configPath = Join-Path $configDir "bridge.toml"
 ```
 
-The package installs the `remotty` command and downloads the matching Windows binary from the GitHub Release for that package version.
-`npm root -g` returns the global npm package folder. The next two lines move PowerShell into the installed `remotty` folder so `Copy-Item` can read the bundled `bridge.toml`. Open the same folder in the Codex App in step 3.
-The remaining lines copy the starter config to `%APPDATA%\remotty\bridge.toml`, so your settings and runtime state are not stored inside the global npm package folder.
+This installs the `remotty` command and downloads the matching Windows binary.
 
-If you need to install directly from the GitHub Release tarball:
+- **2. Move into the installed package folder.**
 
 ```powershell
-npm install -g https://github.com/Sora-bluesky/remotty/releases/latest/download/remotty.tgz
 $remottyRoot = Join-Path (npm root -g) "remotty"
 Set-Location $remottyRoot
+```
+
+Open this same `$remottyRoot` folder in the Codex App when you install the local plugin.
+
+- **3. Copy the starter config to your user config folder.**
+
+```powershell
 $configDir = Join-Path $env:APPDATA "remotty"
 New-Item -ItemType Directory -Force -Path $configDir | Out-Null
 Copy-Item -Force .\bridge.toml (Join-Path $configDir "bridge.toml")
 $configPath = Join-Path $configDir "bridge.toml"
 ```
+
+Your settings and runtime state now live under `%APPDATA%\remotty`, not inside the global npm package folder.
 
 For source builds, see [Development](docs/development.md).
 

--- a/docs/telegram-quickstart.ja.md
+++ b/docs/telegram-quickstart.ja.md
@@ -18,36 +18,33 @@
 
 ## 1. `remotty` を入れる
 
-`npm` から入れます。
+- **1. `npm` からインストールします。**
 
 ```powershell
 npm install -g remotty
-$remottyRoot = Join-Path (npm root -g) "remotty"
-Set-Location $remottyRoot
-$configDir = Join-Path $env:APPDATA "remotty"
-New-Item -ItemType Directory -Force -Path $configDir | Out-Null
-Copy-Item -Force .\bridge.toml (Join-Path $configDir "bridge.toml")
-$configPath = Join-Path $configDir "bridge.toml"
 ```
 
-この手順で `remotty` コマンドが入り、同じ版の Windows 用バイナリも取得されます。
-`npm root -g` は、グローバル npm パッケージの保存先を返します。
-次の2行で、同梱の `bridge.toml` を `Copy-Item` で読める場所へ移動します。
-手順3では、同じフォルダを Codex App から開きます。
-残りの行は、設定の土台を `%APPDATA%\remotty\bridge.toml` へコピーします。
-設定と実行時の状態を、グローバル npm パッケージフォルダに置かないためです。
+このコマンドで `remotty` が入り、同じ版の Windows 用バイナリも取得されます。
 
-GitHub Release の tarball から直接入れたい場合は、次を使います。
+- **2. インストール先のフォルダへ移動します。**
 
 ```powershell
-npm install -g https://github.com/Sora-bluesky/remotty/releases/latest/download/remotty.tgz
 $remottyRoot = Join-Path (npm root -g) "remotty"
 Set-Location $remottyRoot
+```
+
+あとでローカルプラグインを入れる時に、この `$remottyRoot` フォルダを Codex App から開きます。
+
+- **3. 設定ファイルをユーザー用の設定フォルダへコピーします。**
+
+```powershell
 $configDir = Join-Path $env:APPDATA "remotty"
 New-Item -ItemType Directory -Force -Path $configDir | Out-Null
 Copy-Item -Force .\bridge.toml (Join-Path $configDir "bridge.toml")
 $configPath = Join-Path $configDir "bridge.toml"
 ```
+
+設定と実行時の状態は、グローバル npm パッケージフォルダではなく `%APPDATA%\remotty` に置かれます。
 
 ## 2. Telegram bot を作る
 

--- a/docs/telegram-quickstart.md
+++ b/docs/telegram-quickstart.md
@@ -18,33 +18,33 @@ Use a dedicated bot for `remotty` when possible.
 
 ## 1. Install `remotty`
 
-Install from npm:
+- **1. Install from npm.**
 
 ```powershell
 npm install -g remotty
-$remottyRoot = Join-Path (npm root -g) "remotty"
-Set-Location $remottyRoot
-$configDir = Join-Path $env:APPDATA "remotty"
-New-Item -ItemType Directory -Force -Path $configDir | Out-Null
-Copy-Item -Force .\bridge.toml (Join-Path $configDir "bridge.toml")
-$configPath = Join-Path $configDir "bridge.toml"
 ```
 
 This installs the `remotty` command and downloads the matching Windows binary.
-`npm root -g` returns the global npm package folder. The next two lines move PowerShell into the installed `remotty` folder so `Copy-Item` can read the bundled `bridge.toml`. Open the same folder in the Codex App in step 3.
-The remaining lines copy the starter config to `%APPDATA%\remotty\bridge.toml`, so your settings and runtime state are not stored inside the global npm package folder.
 
-If you need to install directly from the GitHub Release tarball:
+- **2. Move into the installed package folder.**
 
 ```powershell
-npm install -g https://github.com/Sora-bluesky/remotty/releases/latest/download/remotty.tgz
 $remottyRoot = Join-Path (npm root -g) "remotty"
 Set-Location $remottyRoot
+```
+
+Open this same `$remottyRoot` folder in the Codex App when you install the local plugin.
+
+- **3. Copy the starter config to your user config folder.**
+
+```powershell
 $configDir = Join-Path $env:APPDATA "remotty"
 New-Item -ItemType Directory -Force -Path $configDir | Out-Null
 Copy-Item -Force .\bridge.toml (Join-Path $configDir "bridge.toml")
 $configPath = Join-Path $configDir "bridge.toml"
 ```
+
+Your settings and runtime state now live under `%APPDATA%\remotty`, not inside the global npm package folder.
 
 ## 2. Create a Telegram Bot
 

--- a/tests/public_surface.rs
+++ b/tests/public_surface.rs
@@ -80,7 +80,7 @@ fn npm_package_keeps_binary_install_contract() -> Result<()> {
     assert!(release_workflow.contains("npm publish ./release/remotty-*.tgz --access public"));
     assert!(readme.contains("docs/assets/hero.png"));
     assert!(readme.contains("npm install -g remotty"));
-    assert!(readme.contains("releases/latest/download/remotty.tgz"));
+    assert!(!readme.contains("releases/latest/download/remotty.tgz"));
     assert!(development_doc.contains("NPM_TOKEN"));
     assert!(development_doc.contains("npm publish .\\release\\remotty.tgz"));
 


### PR DESCRIPTION
## Summary
- remove the GitHub Release tarball install path from user-facing setup docs
- split the npm install setup into short numbered substeps
- update the public-surface test so README keeps the npm registry path as the primary install route

## Validation
- `cargo fmt -- --check`
- `cargo test --test public_surface`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File .\scripts\audit-secret-surface.ps1`
- `pwsh -NoProfile -File .\scripts\audit-doc-terminology.ps1`
- `npm pack --dry-run --json`
- Opus review of changed install sections