### PR TITLE
docs: improve Japanese thread wording

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -79,7 +79,7 @@ Telegram bot token を保存して
 Telegram に表示された pairing code でペアリングして
 Telegram の allowlist を有効化して
 状態を確認して
-Codex スレッドを一覧して
+Codex スレッドを表示して
 ```
 
 bot token は、`remotty` が開く PowerShell にだけ入力します。

--- a/docs/telegram-quickstart.ja.md
+++ b/docs/telegram-quickstart.ja.md
@@ -234,7 +234,7 @@ Codex App では、`@remotty` を選びます。
 次のように依頼します。
 
 ```text
-Codex スレッドを一覧して
+Codex スレッドを表示して
 ```
 
 Codex CLI では、次を実行します。


### PR DESCRIPTION
## Summary
- Replace the unnatural Japanese phrase for listing Codex threads.
- Keep the quickstart and README wording aligned.

## Test Plan
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File .\scripts\audit-secret-surface.ps1`