### PR TITLE
docs: localize Japanese quickstart test message

### DIFF
--- a/docs/telegram-quickstart.ja.md
+++ b/docs/telegram-quickstart.ja.md
@@ -258,7 +258,7 @@ Telegram から続けたいスレッドを選びます。
 Telegram で次を送ります。
 
 ```text
-Summarize the current thread and suggest the next step.
+このスレッドの内容を要約して、次にやることを提案してください。
 ```
 
 `remotty` は選択済みスレッドへ文を渡します。


### PR DESCRIPTION
## Summary
- Replace the English Telegram test prompt in the Japanese quickstart.
- Keep the English quickstart unchanged.

## Test Plan
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File .\scripts\audit-secret-surface.ps1`