### PR TITLE
Fix plugin version drift and current-session fallback docs

### DIFF
--- a/docs/telegram-quickstart.ja.md
+++ b/docs/telegram-quickstart.ja.md
@@ -317,6 +317,25 @@ Codex が承認を求めると、`remotty` は Telegram へ中継します。
 
 ### 接続の Q&A
 
+> Q. 現在の Codex App チャットで `@remotty` が出ません。
+>
+> A. 今のチャットは閉じないでください。
+> PowerShell で、対象プロジェクトへ先に移動します。
+>
+> ```powershell
+> Set-Location C:\path\to\your-project
+> ```
+>
+> その後、次を実行します。
+>
+> ```powershell
+> remotty config workspace upsert --config $configPath --path (Get-Location).Path
+> ```
+>
+> この操作は、プロジェクトのルートにファイルを作りません。
+> 残りの設定も PowerShell で進められます。
+> 後で Codex App に `@remotty` が出たら、そこへ戻れます。
+
 > Q. bot が返信しません。
 >
 > A. まずブリッジが動いているか確認します。Codex App では `@remotty` で状態確認を依頼します。PowerShell では `remotty service status` と `remotty telegram live-env-check --config $configPath` を実行します。webhook 状態が `webhook-configured` なら polling へ戻します。

--- a/docs/telegram-quickstart.md
+++ b/docs/telegram-quickstart.md
@@ -317,6 +317,25 @@ The decision is returned to the same Codex turn.
 
 ### Connection Q&A
 
+> Q. `@remotty` does not appear in the current Codex App chat.
+>
+> A. Keep the current chat open.
+> In PowerShell, move to the project folder first:
+>
+> ```powershell
+> Set-Location C:\path\to\your-project
+> ```
+>
+> Then run:
+>
+> ```powershell
+> remotty config workspace upsert --config $configPath --path (Get-Location).Path
+> ```
+>
+> This registers the project without creating files in the project root.
+> Then continue the remaining setup from PowerShell.
+> If `@remotty` appears later in Codex App, you can return there.
+
 > Q. The bot does not reply.
 >
 > A. First confirm the bridge is still running. In Codex App, ask `@remotty` to check status. In PowerShell, run `remotty service status` and `remotty telegram live-env-check --config $configPath`. If the webhook status is `webhook-configured`, switch the bot back to polling.

--- a/plugins/remotty/.codex-plugin/plugin.json
+++ b/plugins/remotty/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "remotty",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Setup and operations for the remotty Windows bridge for Codex and Telegram.",
   "author": {
     "name": "Sora-bluesky",

--- a/scripts/audit-public-surface.ps1
+++ b/scripts/audit-public-surface.ps1
@@ -206,6 +206,22 @@ Assert-FileContains -Path 'plugins/remotty/skills/remotty-configure/SKILL.md' -N
 Assert-FileContains -Path 'plugins/remotty/skills/remotty-start/SKILL.md' -Needle 'remotty service start'
 Assert-FileContains -Path 'plugins/remotty/skills/remotty-status/SKILL.md' -Needle 'remotty telegram policy allowlist'
 
+if (-not (Test-Path -LiteralPath 'package.json')) {
+    $failures.Add("package.json must exist for version audit.") | Out-Null
+} elseif (-not (Test-Path -LiteralPath 'plugins/remotty/.codex-plugin/plugin.json')) {
+    $failures.Add("plugin manifest must exist for version audit.") | Out-Null
+} else {
+    $packageJson = Get-Content -LiteralPath 'package.json' -Raw | ConvertFrom-Json
+    $pluginJson = Get-Content -LiteralPath 'plugins/remotty/.codex-plugin/plugin.json' -Raw | ConvertFrom-Json
+    $packageVersion = [string]$packageJson.version
+    $pluginVersion = [string]$pluginJson.version
+    if ([string]::IsNullOrWhiteSpace($packageVersion) -or
+        [string]::IsNullOrWhiteSpace($pluginVersion) -or
+        $packageVersion -ne $pluginVersion) {
+        $failures.Add("plugin manifest version must match package version.") | Out-Null
+    }
+}
+
 if (Test-Path -LiteralPath 'plugins/remotty/README.md') {
     $pluginReadme = Get-Content -LiteralPath 'plugins/remotty/README.md' -Raw
     foreach ($forbidden in @('fakechat', '/remotty-fakechat-demo', '/remotty-smoke')) {

--- a/tests/public_surface.rs
+++ b/tests/public_surface.rs
@@ -118,6 +118,19 @@ fn npm_package_keeps_binary_install_contract() -> Result<()> {
     assert!(installer.contains("releases/download"));
     assert!(wrapper.contains("remotty.exe"));
     assert!(plugin_manifest.contains(r#""skills": "./skills/""#));
+    let package_json: serde_json::Value = serde_json::from_str(&package)?;
+    let plugin_json: serde_json::Value = serde_json::from_str(&plugin_manifest)?;
+    let package_version = package_json["version"]
+        .as_str()
+        .map(str::trim)
+        .filter(|version| !version.is_empty())
+        .context("package version must be present")?;
+    let plugin_version = plugin_json["version"]
+        .as_str()
+        .map(str::trim)
+        .filter(|version| !version.is_empty())
+        .context("plugin manifest version must be present")?;
+    assert_eq!(package_version, plugin_version);
     assert!(!plugin_readme.contains("fakechat"));
     assert!(!plugin_readme.contains("/remotty-fakechat-demo"));
     assert!(!plugin_readme.contains("/remotty-smoke"));
@@ -177,6 +190,7 @@ fn public_docs_explain_thread_setup_and_advanced_mode() -> Result<()> {
     assert!(quickstart.contains("does not create files in the project root"));
     assert!(quickstart.contains("Security Q&A"));
     assert!(quickstart.contains("Connection Q&A"));
+    assert!(quickstart.contains("@remotty` does not appear"));
     assert!(quickstart.contains("Pairing Q&A"));
     assert!(quickstart.contains("Thread Selection Q&A"));
     assert!(quickstart.contains("Windows protected storage"));
@@ -202,6 +216,7 @@ fn public_docs_explain_thread_setup_and_advanced_mode() -> Result<()> {
     assert!(quickstart_ja.contains("プロジェクトのルートに"));
     assert!(quickstart_ja.contains("安全性の Q&A"));
     assert!(quickstart_ja.contains("接続の Q&A"));
+    assert!(quickstart_ja.contains("`@remotty` が出ません"));
     assert!(quickstart_ja.contains("ペアリングの Q&A"));
     assert!(quickstart_ja.contains("スレッド選択の Q&A"));
     assert!(quickstart_ja.contains("Windows の保護領域"));


### PR DESCRIPTION
## Summary
- sync the bundled remotty plugin manifest version with the npm package version
- add CI/public-surface checks for package and plugin version drift
- document the PowerShell fallback when @remotty is unavailable in an existing Codex App chat

Fixes #86

## Review
- Opus reviewed the public documentation and version guard changes

## Tests
- cargo fmt --all
- git diff --check
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1
- pwsh -NoProfile -File .\\scripts\\audit-secret-surface.ps1
- cargo test --test public_surface
- cargo test