### PR TITLE
Fix release version sync for plugin manifest

### DIFF
--- a/scripts/bump-version.ps1
+++ b/scripts/bump-version.ps1
@@ -15,6 +15,7 @@ $versionFile = Join-Path $resolvedRepoRoot 'VERSION'
 $cargoTomlPath = Join-Path $resolvedRepoRoot 'Cargo.toml'
 $cargoLockPath = Join-Path $resolvedRepoRoot 'Cargo.lock'
 $packageJsonPath = Join-Path $resolvedRepoRoot 'package.json'
+$pluginManifestPath = Join-Path $resolvedRepoRoot 'plugins/remotty/.codex-plugin/plugin.json'
 $syncRoadmapScript = Join-Path $PSScriptRoot 'sync-roadmap.ps1'
 $generateNotesScript = Join-Path $PSScriptRoot 'generate-release-notes.ps1'
 $validatePlanningScript = Join-Path $PSScriptRoot 'validate-planning.ps1'
@@ -77,6 +78,7 @@ if (-not $SyncOnly) {
 Set-CargoPackageVersion -CargoTomlPath $cargoTomlPath -Version $normalizedVersion
 Set-CargoLockPackageVersion -CargoLockPath $cargoLockPath -PackageName 'remotty' -Version $normalizedVersion
 Set-NpmPackageVersion -PackageJsonPath $packageJsonPath -Version $normalizedVersion
+Set-NpmPackageVersion -PackageJsonPath $pluginManifestPath -Version $normalizedVersion
 
 if ($SyncOnly) {
     Write-Output ("Synced version files to {0}" -f $normalizedVersion)
@@ -85,8 +87,8 @@ if ($SyncOnly) {
 
 Push-Location $resolvedRepoRoot
 try {
-    git add VERSION Cargo.toml Cargo.lock package.json
-    Assert-NativeSuccess "git add VERSION Cargo.toml Cargo.lock package.json"
+    git add VERSION Cargo.toml Cargo.lock package.json plugins/remotty/.codex-plugin/plugin.json
+    Assert-NativeSuccess "git add VERSION Cargo.toml Cargo.lock package.json plugins/remotty/.codex-plugin/plugin.json"
     git commit -m "chore: bump version to $normalizedVersion" | Out-Null
     Assert-NativeSuccess "git commit"
     git push -u origin $branch | Out-Null

--- a/tests/release_automation.rs
+++ b/tests/release_automation.rs
@@ -228,6 +228,12 @@ fn bump_version_sync_only_updates_version_sources() -> Result<()> {
     let cargo_toml_path = temp.path().join("Cargo.toml");
     let cargo_lock_path = temp.path().join("Cargo.lock");
     let package_json_path = temp.path().join("package.json");
+    let plugin_manifest_path = temp
+        .path()
+        .join("plugins")
+        .join("remotty")
+        .join(".codex-plugin")
+        .join("plugin.json");
     let version_path = temp.path().join("VERSION");
 
     write_file(
@@ -263,6 +269,14 @@ version = "4.5.0"
 }
 "#,
     )?;
+    write_file(
+        &plugin_manifest_path,
+        r#"{
+  "name": "remotty",
+  "version": "0.1.0"
+}
+"#,
+    )?;
     write_file(&version_path, "0.1.0")?;
 
     let output = Command::new(powershell())
@@ -291,6 +305,8 @@ version = "4.5.0"
     assert!(cargo_lock.contains("name = \"clap\"\nversion = \"4.5.0\""));
     let package_json = fs::read_to_string(&package_json_path)?;
     assert!(package_json.contains("\"version\": \"0.1.8\""));
+    let plugin_manifest = fs::read_to_string(&plugin_manifest_path)?;
+    assert!(plugin_manifest.contains("\"version\": \"0.1.8\""));
     assert_eq!(fs::read_to_string(&version_path)?, "0.1.8");
 
     Ok(())
@@ -645,7 +661,7 @@ fn bump_version_checks_native_release_command_failures() -> Result<()> {
 
     for command in [
         "git switch -c $branch",
-        "git add VERSION Cargo.toml Cargo.lock package.json",
+        "git add VERSION Cargo.toml Cargo.lock package.json plugins/remotty/.codex-plugin/plugin.json",
         "git commit",
         "git push -u origin $branch",
         "gh pr create",


### PR DESCRIPTION
## Summary
- update the release bump script to sync the bundled Codex plugin manifest version
- extend release automation tests so plugin manifest drift is caught during version bumps

## Tests
- cargo fmt --all
- git diff --check
- cargo test --test release_automation
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1
- pwsh -NoProfile -File .\\scripts\\audit-secret-surface.ps1