### PR TITLE
Sharpen README positioning

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -4,7 +4,11 @@
 
 ![remotty: Codex と Telegram をつなぐ Windows ブリッジ](docs/assets/hero.png)
 
-`remotty` は、Telegram から手元の Codex 作業を続けるためのツールです。
+`remotty` は、汎用の遠隔操作ツールではありません。
+Windows 上の Codex 作業を、普段使う Telegram から続けるためのブリッジです。
+
+`remotty` は、Telegram から Codex 作業の続きを進められるようにします。
+新しいモバイルアプリを入れる必要はありません。
 
 Telegram bot へメッセージを送ります。
 `remotty` が Windows PC で受け取り、選択した Codex スレッドへ渡します。
@@ -13,14 +17,6 @@ Telegram bot へメッセージを送ります。
 `remotty` は公開 webhook サーバを使いません。
 開いている Codex App 画面へキー入力もしません。
 ローカルの `codex` コマンドを通じて Codex とやり取りします。
-
-> [!WARNING]
-> **免責**
->
-> 本プロジェクトは、OpenAI の支援、承認、提携を受けていません。
-> `Codex`、`ChatGPT`、関連する名称は OpenAI の商標です。
-> ここでは、連携先のローカルツールを説明する目的でのみ使っています。
-> その他の商標は、それぞれの権利者に帰属します。
 
 ## できること
 
@@ -123,3 +119,12 @@ Telegram で使います。
 ## ライセンス
 
 [MIT](LICENSE)
+
+## 免責
+
+本プロジェクトは、非公式のコミュニティプロジェクトです。
+本プロジェクトは、OpenAI の支援、承認、提携を受けていません。
+
+`Codex`、`ChatGPT`、関連する名称は OpenAI の商標です。
+ここでは、連携先のローカルツールを説明する目的でのみ使っています。
+その他の商標は、それぞれの権利者に帰属します。

--- a/README.md
+++ b/README.md
@@ -4,7 +4,12 @@
 
 ![remotty: Windows bridge for Codex and Telegram](docs/assets/hero.png)
 
-`remotty` lets you continue local Codex work from Telegram.
+`remotty` is not a general-purpose remote control tool.
+It is a bridge for continuing Codex work on Windows from the Telegram app you
+already use.
+
+`remotty` lets you continue Codex work from Telegram.
+There is no new mobile app to install.
 
 You send a message to your Telegram bot. `remotty` receives it on your Windows
 PC, sends it to the selected Codex thread, and returns the reply to the same
@@ -13,15 +18,6 @@ Telegram chat.
 `remotty` does not expose a public webhook server. It also does not type into
 the open Codex App window. It talks to local Codex through the local `codex`
 command.
-
-> [!WARNING]
-> **Disclaimer**
->
-> This is an unofficial community project. It is not affiliated with,
-> endorsed by, or sponsored by OpenAI.
-> `Codex`, `ChatGPT`, and related marks are trademarks of OpenAI.
-> They are referenced here only to describe the local tools that `remotty`
-> works with. All other trademarks belong to their owners.
 
 ## What It Does
 
@@ -128,3 +124,12 @@ Telegram.
 ## License
 
 [MIT](LICENSE)
+
+## Disclaimer
+
+This is an unofficial community project. It is not affiliated with, endorsed by,
+or sponsored by OpenAI.
+
+`Codex`, `ChatGPT`, and related marks are trademarks of OpenAI.
+They are referenced here only to describe the local tools that `remotty` works
+with. All other trademarks belong to their owners.


### PR DESCRIPTION
## Summary
- reposition remotty as a Telegram bridge for Codex work on Windows
- clarify that remotty is not a general-purpose remote control tool
- move the disclaimer from the opening to the end of both READMEs

## Review
- Opus reviewed the public README copy

## Tests
- git diff --check
- pwsh -NoProfile -File .\\scripts\\audit-public-surface.ps1
- pwsh -NoProfile -File .\\scripts\\audit-secret-surface.ps1
- cargo test --test public_surface
- cargo test