### PR TITLE
Allow Telegram thread selection by title

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -96,10 +96,15 @@ Telegram で使います。
 /stop
 /approve <request_id>
 /deny <request_id>
-/remotty-sessions <thread_id>
+/remotty-sessions <スレッド名または ID>
 /workspace
 /workspace <id>
 ```
+
+スレッド名に空白があっても、そのまま送れます。
+引用符は不要です。
+同じ名前が複数ある場合は、表示された `ID` を使います。
+名前が別スレッドの `ID` に見える場合も、表示された `ID` を使います。
 
 ## 安全な情報の扱い
 

--- a/README.md
+++ b/README.md
@@ -100,10 +100,15 @@ Run these in Telegram:
 /stop
 /approve <request_id>
 /deny <request_id>
-/remotty-sessions <thread_id>
+/remotty-sessions <thread title or ID>
 /workspace
 /workspace <id>
 ```
+
+Thread titles may include spaces.
+No quotes are needed.
+If more than one thread matches, use the shown `ID`.
+If a title also looks like another thread's `ID`, use the shown `ID`.
 
 ## Security
 

--- a/docs/telegram-quickstart.ja.md
+++ b/docs/telegram-quickstart.ja.md
@@ -247,9 +247,18 @@ remotty telegram sessions --config $configPath
 Telegram から続けたいスレッドを選びます。
 対象の Telegram チャットで次を送ります。
 
+たとえば、スレッド名が `Start workspace session` の場合です。
+
 ```text
-/remotty-sessions <thread_id>
+/remotty-sessions Start workspace session
 ```
+
+`/remotty-sessions` の後ろは、まとめて1つの名前として扱います。
+引用符は不要です。
+大文字と小文字は区別しません。
+`remotty` は `ID`、完全な名前、`ID` の先頭、名前の一部の順に探します。
+複数のスレッドが一致した場合は、表示された `ID` を使います。
+名前が別スレッドの `ID` に見える場合も、`ID` を指定し直してください。
 
 対応付けは `%APPDATA%\remotty` へ保存します。
 プロジェクトのリポジトリには書き込みません。

--- a/docs/telegram-quickstart.md
+++ b/docs/telegram-quickstart.md
@@ -250,9 +250,18 @@ remotty telegram sessions --config $configPath
 Choose the thread you want Telegram to continue.
 Then send this in the target Telegram chat:
 
+For example, if the thread title is `Start workspace session`:
+
 ```text
-/remotty-sessions <thread_id>
+/remotty-sessions Start workspace session
 ```
+
+Everything after `/remotty-sessions` is treated as one title.
+No quotes are needed.
+Matching is case-insensitive.
+`remotty` tries exact `ID`, exact title, `ID` prefix, then a title substring match.
+If more than one thread matches, use the shown `ID`.
+If a title also looks like another thread's `ID`, `remotty` asks you to choose by `ID`.
 
 This binding is stored under `%APPDATA%\remotty`.
 It is not written into your project repository.

--- a/docs/upgrading.ja.md
+++ b/docs/upgrading.ja.md
@@ -20,7 +20,7 @@ transport = "app_server"
 
 ```text
 /remotty-sessions
-/remotty-sessions <thread_id>
+/remotty-sessions <スレッド名または ID>
 ```
 
 ## 設定が `exec` の場合

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -19,7 +19,7 @@ This lets Telegram continue the Codex thread you select with:
 
 ```text
 /remotty-sessions
-/remotty-sessions <thread_id>
+/remotty-sessions <thread title or ID>
 ```
 
 ## If Your Config Uses `exec`

--- a/scripts/audit-public-surface.ps1
+++ b/scripts/audit-public-surface.ps1
@@ -153,7 +153,12 @@ foreach ($readmePath in @('README.md', 'README.ja.md')) {
         }
     }
 }
-Assert-FileContains -Path 'docs/telegram-quickstart.md' -Needle '/remotty-sessions <thread_id>'
+Assert-FileContains -Path 'docs/telegram-quickstart.md' -Needle '/remotty-sessions Start workspace session'
+Assert-FileContains -Path 'docs/telegram-quickstart.md' -Needle 'if the thread title is `Start workspace session`'
+Assert-FileContains -Path 'docs/telegram-quickstart.md' -Needle 'No quotes are needed.'
+Assert-FileContains -Path 'docs/telegram-quickstart.md' -Needle 'Matching is case-insensitive.'
+Assert-FileContains -Path 'docs/telegram-quickstart.md' -Needle 'exact `ID`, exact title, `ID` prefix, then a title substring match'
+Assert-FileContains -Path 'docs/telegram-quickstart.md' -Needle 'If more than one thread matches, use the shown `ID`.'
 Assert-FileContains -Path 'docs/telegram-quickstart.md' -Needle 'Register this project with remotty'
 Assert-FileContains -Path 'docs/telegram-quickstart.md' -Needle 'Codex CLI users run'
 Assert-FileContains -Path 'docs/telegram-quickstart.md' -Needle 'remotty config workspace upsert'
@@ -176,7 +181,12 @@ Assert-FileContains -Path 'docs/telegram-quickstart.md' -Needle 'Windows protect
 Assert-FileContains -Path 'docs/telegram-quickstart.md' -Needle 'paired senders'
 Assert-FileContains -Path 'docs/telegram-quickstart.md' -Needle 'Do not paste the token into Codex App chat.'
 Assert-FileContains -Path 'docs/telegram-quickstart.md' -Needle 'Regenerate it with `@BotFather`'
-Assert-FileContains -Path 'docs/telegram-quickstart.ja.md' -Needle '/remotty-sessions <thread_id>'
+Assert-FileContains -Path 'docs/telegram-quickstart.ja.md' -Needle '/remotty-sessions Start workspace session'
+Assert-FileContains -Path 'docs/telegram-quickstart.ja.md' -Needle 'スレッド名が `Start workspace session` の場合'
+Assert-FileContains -Path 'docs/telegram-quickstart.ja.md' -Needle '引用符は不要です'
+Assert-FileContains -Path 'docs/telegram-quickstart.ja.md' -Needle '大文字と小文字は区別しません'
+Assert-FileContains -Path 'docs/telegram-quickstart.ja.md' -Needle '`ID`、完全な名前、`ID` の先頭、名前の一部'
+Assert-FileContains -Path 'docs/telegram-quickstart.ja.md' -Needle '複数のスレッドが一致した場合は、表示された `ID` を使います'
 Assert-FileContains -Path 'docs/telegram-quickstart.ja.md' -Needle 'このプロジェクトを remotty に登録して'
 Assert-FileContains -Path 'docs/telegram-quickstart.ja.md' -Needle 'Codex CLI では'
 Assert-FileContains -Path 'docs/telegram-quickstart.ja.md' -Needle 'remotty config workspace upsert'

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -800,13 +800,17 @@ async fn handle_sessions_command(
     thread_id: Option<&str>,
 ) -> Result<String> {
     let Some(thread_id) = thread_id.map(str::trim).filter(|value| !value.is_empty()) else {
-        let threads = codex.list_threads(10, None).await?;
+        let threads = codex.list_threads(25, None).await?;
         return Ok(format_sessions_message(&threads));
     };
 
-    let threads = codex.list_threads(25, Some(thread_id)).await?;
-    let Some(selected) = find_selected_thread(&threads, thread_id) else {
-        return Ok(format_thread_not_found_message(thread_id));
+    let mut threads = codex.list_threads(25, None).await?;
+    merge_unique_threads(&mut threads, codex.list_threads(25, Some(thread_id)).await?);
+    let matches = find_selected_threads(&threads, thread_id);
+    let selected = match matches.as_slice() {
+        [selected] => *selected,
+        [] => return Ok(format_thread_not_found_message(thread_id)),
+        ambiguous => return Ok(format_ambiguous_thread_message(thread_id, ambiguous)),
     };
     let workspace = resolve_workspace(config, lane)?;
     store.upsert_codex_thread_binding(NewCodexThreadBinding {
@@ -819,24 +823,97 @@ async fn handle_sessions_command(
         model: selected.model.clone(),
         codex_updated_at: selected.updated_at.clone(),
     })?;
+    let title = selected.title.as_deref().unwrap_or("タイトルなし");
     Ok(format!(
-        "この会話を Codex スレッド `{}` に対応付けました。\n次の入力から、このスレッドへ戻せるようになります。",
+        "この会話を Codex スレッド `{title}` に対応付けました。\n技術 ID: `{}`\n次の入力から、このスレッドへ戻せるようになります。",
         selected.thread_id
     ))
 }
 
-fn find_selected_thread<'a>(
+fn find_selected_threads<'a>(
     threads: &'a [CodexThreadSummary],
-    thread_id: &str,
-) -> Option<&'a CodexThreadSummary> {
+    query: &str,
+) -> Vec<&'a CodexThreadSummary> {
+    let exact_id = threads
+        .iter()
+        .filter(|thread| thread.thread_id.eq_ignore_ascii_case(query))
+        .collect::<Vec<_>>();
+    if !exact_id.is_empty() {
+        return exact_id;
+    }
+
+    let exact_title = threads
+        .iter()
+        .filter(|thread| title_eq(thread, query))
+        .collect::<Vec<_>>();
+    let prefix_id = threads
+        .iter()
+        .filter(|thread| id_prefix_eq(thread, query))
+        .collect::<Vec<_>>();
+
+    if !exact_title.is_empty() {
+        let mut matches = exact_title;
+        for thread in prefix_id {
+            if !matches
+                .iter()
+                .any(|existing| existing.thread_id == thread.thread_id)
+            {
+                matches.push(thread);
+            }
+        }
+        return matches;
+    }
+
+    if !prefix_id.is_empty() {
+        return prefix_id;
+    }
+
     threads
         .iter()
-        .find(|thread| thread.thread_id.eq_ignore_ascii_case(thread_id))
-        .or_else(|| {
-            threads
-                .iter()
-                .find(|thread| thread.thread_id.starts_with(thread_id))
-        })
+        .filter(|thread| title_contains(thread, query))
+        .collect::<Vec<_>>()
+}
+
+fn id_prefix_eq(thread: &CodexThreadSummary, query: &str) -> bool {
+    normalize_thread_lookup(&thread.thread_id).starts_with(&normalize_thread_lookup(query))
+}
+
+fn merge_unique_threads(
+    threads: &mut Vec<CodexThreadSummary>,
+    extra_threads: Vec<CodexThreadSummary>,
+) {
+    for thread in extra_threads {
+        if !threads
+            .iter()
+            .any(|existing| existing.thread_id == thread.thread_id)
+        {
+            threads.push(thread);
+        }
+    }
+}
+
+fn normalize_thread_lookup(value: &str) -> String {
+    value.trim().to_lowercase()
+}
+
+fn title_eq(thread: &CodexThreadSummary, query: &str) -> bool {
+    thread
+        .title
+        .as_deref()
+        .map(|title| normalize_thread_lookup(title) == normalize_thread_lookup(query))
+        .unwrap_or(false)
+}
+
+fn title_contains(thread: &CodexThreadSummary, query: &str) -> bool {
+    let query = normalize_thread_lookup(query);
+    if query.is_empty() {
+        return false;
+    }
+    thread
+        .title
+        .as_deref()
+        .map(|title| normalize_thread_lookup(title).contains(&query))
+        .unwrap_or(false)
 }
 
 async fn handle_approval_decision_message(
@@ -1526,7 +1603,7 @@ fn format_help_message() -> String {
         "/workspace",
         "/workspace <id>",
         "/remotty-sessions",
-        "/remotty-sessions <thread_id>",
+        "/remotty-sessions <title or ID>",
         "/mode await_reply",
         "/mode completion_checks",
         "/mode infinite",
@@ -1600,16 +1677,96 @@ fn format_sessions_message(threads: &[CodexThreadSummary]) -> String {
     let mut lines = vec!["保存済みの Codex スレッド:".to_owned()];
     for thread in threads.iter().take(10) {
         let title = thread.title.as_deref().unwrap_or("タイトルなし");
-        lines.push(format!("- `{}` {}", thread.thread_id, title));
+        lines.push(format!("- {title}"));
+        if let Some(cwd) = thread.cwd.as_deref() {
+            lines.push(format!("  project: `{cwd}`"));
+        }
+        lines.push(format!(
+            "  select: `/remotty-sessions {}`",
+            thread_selection_target_for_list(thread, threads)
+        ));
+        lines.push(format!("  ID: `{}`", thread.thread_id));
     }
-    lines.push("選択: `/remotty-sessions <thread_id>`".to_owned());
+    lines.push("選択: `/remotty-sessions <title or ID>`".to_owned());
     lines.join("\n")
 }
 
 fn format_thread_not_found_message(thread_id: &str) -> String {
     format!(
-        "Codex スレッド `{thread_id}` は見つかりませんでした。\n`/remotty-sessions` で最新の一覧を確認し、表示された ID を指定してください。"
+        "Codex スレッド `{thread_id}` は見つかりませんでした。\n`/remotty-sessions` で最新の一覧を確認し、表示された名前を指定してください。"
     )
+}
+
+fn format_ambiguous_thread_message(query: &str, threads: &[&CodexThreadSummary]) -> String {
+    let mut lines = vec![format!(
+        "`{query}` に一致する Codex スレッドが複数あります。"
+    )];
+    for thread in threads.iter().take(10) {
+        let title = thread.title.as_deref().unwrap_or("タイトルなし");
+        lines.push(format!("- {title}"));
+        if let Some(cwd) = thread.cwd.as_deref() {
+            lines.push(format!("  project: `{cwd}`"));
+        }
+        lines.push(format!(
+            "  select: `/remotty-sessions {}`",
+            thread.thread_id
+        ));
+        lines.push(format!("  ID: `{}`", thread.thread_id));
+    }
+    lines.push("一意にするため、より長い名前か ID を指定してください。".to_owned());
+    lines.join("\n")
+}
+
+fn thread_selection_target_for_list<'a>(
+    thread: &'a CodexThreadSummary,
+    threads: &[CodexThreadSummary],
+) -> &'a str {
+    if title_is_duplicated(thread, threads) {
+        return &thread.thread_id;
+    }
+    if title_conflicts_with_id_prefix(thread, threads) {
+        return &thread.thread_id;
+    }
+    thread
+        .title
+        .as_deref()
+        .map(str::trim)
+        .filter(|title| !title.is_empty())
+        .unwrap_or(&thread.thread_id)
+}
+
+fn title_conflicts_with_id_prefix(
+    thread: &CodexThreadSummary,
+    threads: &[CodexThreadSummary],
+) -> bool {
+    let Some(title) = normalized_non_empty_title(thread) else {
+        return false;
+    };
+    threads
+        .iter()
+        .any(|candidate| normalize_thread_lookup(&candidate.thread_id).starts_with(&title))
+}
+
+fn title_is_duplicated(thread: &CodexThreadSummary, threads: &[CodexThreadSummary]) -> bool {
+    let Some(title) = normalized_non_empty_title(thread) else {
+        return false;
+    };
+    threads
+        .iter()
+        .filter_map(normalized_non_empty_title)
+        .filter(|other| other == &title)
+        .take(2)
+        .count()
+        > 1
+}
+
+fn normalized_non_empty_title(thread: &CodexThreadSummary) -> Option<String> {
+    thread
+        .title
+        .as_deref()
+        .map(str::trim)
+        .filter(|title| !title.is_empty())
+        .map(normalize_thread_lookup)
 }
 
 async fn persist_approval_requests(
@@ -3016,17 +3173,101 @@ mod tests {
 
     #[test]
     fn format_sessions_message_includes_selection_command() {
-        let message = format_sessions_message(&[CodexThreadSummary {
-            thread_id: "thread-1".to_owned(),
-            title: Some("Fix tests".to_owned()),
-            cwd: None,
-            model: None,
-            updated_at: None,
-        }]);
+        let message = format_sessions_message(&[
+            CodexThreadSummary {
+                thread_id: "thread-1".to_owned(),
+                title: Some("Fix tests".to_owned()),
+                cwd: None,
+                model: None,
+                updated_at: None,
+            },
+            CodexThreadSummary {
+                thread_id: "thread-2".to_owned(),
+                title: None,
+                cwd: None,
+                model: None,
+                updated_at: None,
+            },
+        ]);
 
         assert!(message.contains("thread-1"));
         assert!(message.contains("Fix tests"));
-        assert!(message.contains("/remotty-sessions <thread_id>"));
+        assert!(message.contains("/remotty-sessions Fix tests"));
+        assert!(message.contains("/remotty-sessions thread-2"));
+        assert!(message.contains("/remotty-sessions <title or ID>"));
+    }
+
+    #[test]
+    fn format_sessions_message_uses_id_for_duplicate_titles() {
+        let message = format_sessions_message(&[
+            CodexThreadSummary {
+                thread_id: "thread-1".to_owned(),
+                title: Some("Start workspace session".to_owned()),
+                cwd: None,
+                model: None,
+                updated_at: None,
+            },
+            CodexThreadSummary {
+                thread_id: "thread-2".to_owned(),
+                title: Some("start workspace session".to_owned()),
+                cwd: None,
+                model: None,
+                updated_at: None,
+            },
+        ]);
+
+        assert!(message.contains("/remotty-sessions thread-1"));
+        assert!(message.contains("/remotty-sessions thread-2"));
+    }
+
+    #[test]
+    fn format_sessions_message_uses_id_when_title_matches_id_prefix() {
+        let message = format_sessions_message(&[
+            CodexThreadSummary {
+                thread_id: "thread-abcdef".to_owned(),
+                title: Some("Other work".to_owned()),
+                cwd: None,
+                model: None,
+                updated_at: None,
+            },
+            CodexThreadSummary {
+                thread_id: "thread-title".to_owned(),
+                title: Some("thread-abc".to_owned()),
+                cwd: None,
+                model: None,
+                updated_at: None,
+            },
+        ]);
+
+        assert!(message.contains("/remotty-sessions thread-title"));
+        assert!(!message.contains("select: `/remotty-sessions thread-abc`"));
+    }
+
+    #[test]
+    fn format_sessions_message_uses_id_for_hidden_duplicate_titles() {
+        let mut threads = (0..10)
+            .map(|index| CodexThreadSummary {
+                thread_id: format!("thread-{index}"),
+                title: Some(format!("Thread {index}")),
+                cwd: None,
+                model: None,
+                updated_at: None,
+            })
+            .collect::<Vec<_>>();
+        threads[0].title = Some("Start workspace session".to_owned());
+        threads.push(CodexThreadSummary {
+            thread_id: "thread-hidden".to_owned(),
+            title: Some("start workspace session".to_owned()),
+            cwd: None,
+            model: None,
+            updated_at: None,
+        });
+
+        let message = format_sessions_message(&threads);
+
+        assert!(message.contains("select: `/remotty-sessions thread-0`"));
+        assert!(!message.contains("select: `/remotty-sessions Start workspace session`"));
+        assert!(!message.contains("thread-hidden"));
     }
 
     #[test]
@@ -3039,10 +3280,141 @@ mod tests {
             updated_at: None,
         }];
 
-        let selected =
-            find_selected_thread(&threads, "thread-abc").expect("prefix should select the thread");
+        let matches = find_selected_threads(&threads, "thread-abc");
 
-        assert_eq!(selected.thread_id, "thread-abcdef");
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].thread_id, "thread-abcdef");
+    }
+
+    #[test]
+    fn find_selected_thread_accepts_case_insensitive_prefix_match() {
+        let threads = vec![CodexThreadSummary {
+            thread_id: "Thread-ABCDEF".to_owned(),
+            title: None,
+            cwd: None,
+            model: None,
+            updated_at: None,
+        }];
+
+        let matches = find_selected_threads(&threads, "thread-abc");
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].thread_id, "Thread-ABCDEF");
+    }
+
+    #[test]
+    fn find_selected_thread_accepts_title_match() {
+        let threads = vec![CodexThreadSummary {
+            thread_id: "thread-1".to_owned(),
+            title: Some("Start workspace session".to_owned()),
+            cwd: Some("C:/workspace".to_owned()),
+            model: None,
+            updated_at: None,
+        }];
+
+        let matches = find_selected_threads(&threads, "Start workspace session");
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].thread_id, "thread-1");
+    }
+
+    #[test]
+    fn find_selected_thread_returns_ambiguous_title_and_id_prefix_matches() {
+        let threads = vec![
+            CodexThreadSummary {
+                thread_id: "thread-title".to_owned(),
+                title: Some("thread-abc".to_owned()),
+                cwd: Some("C:/workspace/title".to_owned()),
+                model: None,
+                updated_at: None,
+            },
+            CodexThreadSummary {
+                thread_id: "thread-abcdef".to_owned(),
+                title: Some("Other work".to_owned()),
+                cwd: Some("C:/workspace/prefix".to_owned()),
+                model: None,
+                updated_at: None,
+            },
+        ];
+
+        let matches = find_selected_threads(&threads, "thread-abc");
+
+        assert_eq!(matches.len(), 2);
+        assert!(
+            matches
+                .iter()
+                .any(|thread| thread.thread_id == "thread-title")
+        );
+        assert!(
+            matches
+                .iter()
+                .any(|thread| thread.thread_id == "thread-abcdef")
+        );
+    }
+
+    #[test]
+    fn find_selected_thread_returns_ambiguous_title_matches() {
+        let threads = vec![
+            CodexThreadSummary {
+                thread_id: "thread-1".to_owned(),
+                title: Some("Start workspace session".to_owned()),
+                cwd: Some("C:/workspace/one".to_owned()),
+                model: None,
+                updated_at: None,
+            },
+            CodexThreadSummary {
+                thread_id: "thread-2".to_owned(),
+                title: Some("Start workspace session".to_owned()),
+                cwd: Some("C:/workspace/two".to_owned()),
+                model: None,
+                updated_at: None,
+            },
+        ];
+
+        let matches = find_selected_threads(&threads, "Start workspace session");
+
+        assert_eq!(matches.len(), 2);
+        let message = format_ambiguous_thread_message("Start workspace session", &matches);
+        assert!(message.contains("複数"));
+        assert!(message.contains("thread-1"));
+        assert!(message.contains("thread-2"));
+        assert!(message.contains("/remotty-sessions thread-1"));
+        assert!(message.contains("/remotty-sessions thread-2"));
+    }
+
+    #[test]
+    fn merge_unique_threads_keeps_filtered_duplicate_candidates() {
+        let mut threads = vec![CodexThreadSummary {
+            thread_id: "thread-1".to_owned(),
+            title: Some("Start workspace session".to_owned()),
+            cwd: None,
+            model: None,
+            updated_at: None,
+        }];
+        merge_unique_threads(
+            &mut threads,
+            vec![
+                CodexThreadSummary {
+                    thread_id: "thread-1".to_owned(),
+                    title: Some("Start workspace session".to_owned()),
+                    cwd: None,
+                    model: None,
+                    updated_at: None,
+                },
+                CodexThreadSummary {
+                    thread_id: "thread-2".to_owned(),
+                    title: Some("Start workspace session".to_owned()),
+                    cwd: None,
+                    model: None,
+                    updated_at: None,
+                },
+            ],
+        );
+
+        let matches = find_selected_threads(&threads, "Start workspace session");
+
+        assert_eq!(threads.len(), 2);
+        assert_eq!(matches.len(), 2);
     }
 
     #[test]

--- a/src/telegram.rs
+++ b/src/telegram.rs
@@ -867,8 +867,11 @@ fn render_attachment_summary(attachments: &[TelegramAttachment]) -> String {
 }
 
 pub fn parse_control_command(text: &str) -> Option<TelegramControlCommand> {
-    let mut parts = text.trim().split_whitespace();
-    let command = parse_control_command_name(parts.next()?)?;
+    let text = text.trim();
+    let command_token = text.split_whitespace().next()?;
+    let command = parse_control_command_name(command_token)?;
+    let rest = text[command_token.len()..].trim();
+    let mut parts = rest.split_whitespace();
 
     if command.eq_ignore_ascii_case("help") {
         return parts
@@ -913,12 +916,8 @@ pub fn parse_control_command(text: &str) -> Option<TelegramControlCommand> {
     }
     if command.eq_ignore_ascii_case("sessions") || command.eq_ignore_ascii_case("remotty-sessions")
     {
-        let thread_id = parts.next().map(|value| value.trim().to_owned());
-        if parts.next().is_some() {
-            return None;
-        }
         return Some(TelegramControlCommand::Sessions {
-            thread_id: thread_id.filter(|value| !value.is_empty()),
+            thread_id: (!rest.is_empty()).then_some(rest.to_owned()),
         });
     }
     if command.eq_ignore_ascii_case("mode") {
@@ -1488,6 +1487,26 @@ mod tests {
     }
 
     #[test]
+    fn parses_sessions_command_with_title() {
+        assert_eq!(
+            parse_control_command("/remotty-sessions Start workspace session"),
+            Some(TelegramControlCommand::Sessions {
+                thread_id: Some("Start workspace session".to_owned())
+            })
+        );
+    }
+
+    #[test]
+    fn parses_sessions_command_preserves_inner_title_whitespace() {
+        assert_eq!(
+            parse_control_command("/remotty-sessions Start  workspace  session"),
+            Some(TelegramControlCommand::Sessions {
+                thread_id: Some("Start  workspace  session".to_owned())
+            })
+        );
+    }
+
+    #[test]
     fn parses_stop_command() {
         assert_eq!(
             TelegramControlCommand::parse("/stop"),
@@ -1579,7 +1598,6 @@ mod tests {
         assert_eq!(parse_control_command("/approve req extra"), None);
         assert_eq!(parse_control_command("/deny req extra"), None);
         assert_eq!(parse_control_command("/workspace docs extra"), None);
-        assert_eq!(parse_control_command("/remotty-sessions a b"), None);
     }
 
     #[test]

--- a/src/telegram_cli.rs
+++ b/src/telegram_cli.rs
@@ -235,7 +235,7 @@ pub async fn live_env_check(config_path: impl AsRef<Path>) -> Result<String> {
 pub async fn sessions(config_path: impl AsRef<Path>, filter: Option<&str>) -> Result<String> {
     let config = Config::load(config_path.as_ref())?;
     let runner = CodexRunner::new(config.codex.clone());
-    let threads = runner.list_threads(10, filter).await?;
+    let threads = runner.list_threads(25, filter).await?;
     Ok(format_sessions_summary(&threads))
 }
 
@@ -247,11 +247,72 @@ fn format_sessions_summary(threads: &[CodexThreadSummary]) -> String {
     for thread in threads.iter().take(10) {
         let title = thread.title.as_deref().unwrap_or("untitled");
         let cwd = thread.cwd.as_deref().unwrap_or("cwd unavailable");
-        lines.push(format!("- `{}` {title}", thread.thread_id));
-        lines.push(format!("  cwd: `{cwd}`"));
+        lines.push(format!("- {title}"));
+        lines.push(format!("  project: `{cwd}`"));
+        lines.push(format!(
+            "  select: `/remotty-sessions {}`",
+            thread_selection_target_for_list(thread, threads)
+        ));
+        lines.push(format!("  ID: `{}`", thread.thread_id));
     }
-    lines.push("Telegram select: `/remotty-sessions <thread_id>`".to_owned());
+    lines.push("Telegram select: `/remotty-sessions <title or ID>`".to_owned());
     lines.join("\n")
+}
+
+fn thread_selection_target_for_list<'a>(
+    thread: &'a CodexThreadSummary,
+    threads: &[CodexThreadSummary],
+) -> &'a str {
+    if title_is_duplicated(thread, threads) {
+        return &thread.thread_id;
+    }
+    if title_conflicts_with_id_prefix(thread, threads) {
+        return &thread.thread_id;
+    }
+    thread
+        .title
+        .as_deref()
+        .map(str::trim)
+        .filter(|title| !title.is_empty())
+        .unwrap_or(&thread.thread_id)
+}
+
+fn title_conflicts_with_id_prefix(
+    thread: &CodexThreadSummary,
+    threads: &[CodexThreadSummary],
+) -> bool {
+    let Some(title) = normalized_non_empty_title(thread) else {
+        return false;
+    };
+    threads
+        .iter()
+        .any(|candidate| normalize_thread_lookup(&candidate.thread_id).starts_with(&title))
+}
+
+fn title_is_duplicated(thread: &CodexThreadSummary, threads: &[CodexThreadSummary]) -> bool {
+    let Some(title) = normalized_non_empty_title(thread) else {
+        return false;
+    };
+    threads
+        .iter()
+        .filter_map(normalized_non_empty_title)
+        .filter(|other| other == &title)
+        .take(2)
+        .count()
+        > 1
+}
+
+fn normalized_non_empty_title(thread: &CodexThreadSummary) -> Option<String> {
+    thread
+        .title
+        .as_deref()
+        .map(str::trim)
+        .filter(|title| !title.is_empty())
+        .map(normalize_thread_lookup)
+}
+
+fn normalize_thread_lookup(value: &str) -> String {
+    value.trim().to_lowercase()
 }
 
 fn resolve_secret_ref(config_path: &Path) -> Result<String> {

--- a/tests/public_surface.rs
+++ b/tests/public_surface.rs
@@ -174,7 +174,14 @@ fn public_docs_explain_thread_setup_and_advanced_mode() -> Result<()> {
     assert!(readme_ja.contains("Telegram クイックスタート"));
     assert!(readme_ja.contains("高度な CLI モード"));
     assert!(!readme_ja.contains("docs/development.ja.md"));
-    assert!(quickstart.contains("/remotty-sessions <thread_id>"));
+    assert!(quickstart.contains("/remotty-sessions Start workspace session"));
+    assert!(quickstart.contains("if the thread title is `Start workspace session`"));
+    assert!(quickstart.contains("No quotes are needed."));
+    assert!(quickstart.contains("Matching is case-insensitive."));
+    assert!(
+        quickstart.contains("exact `ID`, exact title, `ID` prefix, then a title substring match")
+    );
+    assert!(quickstart.contains("If more than one thread matches, use the shown `ID`."));
     assert!(quickstart.contains("Register this project with remotty"));
     assert!(quickstart.contains("Codex CLI users run"));
     assert!(quickstart.contains("remotty config workspace upsert"));
@@ -200,7 +207,12 @@ fn public_docs_explain_thread_setup_and_advanced_mode() -> Result<()> {
     assert!(!quickstart.contains("writable_roots"));
     assert!(!quickstart.contains("path = \"C:/Users/you/Documents/project\""));
     assert!(!quickstart.contains(".agents/plugins/marketplace.json"));
-    assert!(quickstart_ja.contains("/remotty-sessions <thread_id>"));
+    assert!(quickstart_ja.contains("/remotty-sessions Start workspace session"));
+    assert!(quickstart_ja.contains("スレッド名が `Start workspace session` の場合"));
+    assert!(quickstart_ja.contains("引用符は不要です"));
+    assert!(quickstart_ja.contains("大文字と小文字は区別しません"));
+    assert!(quickstart_ja.contains("`ID`、完全な名前、`ID` の先頭、名前の一部"));
+    assert!(quickstart_ja.contains("複数のスレッドが一致した場合は、表示された `ID` を使います"));
     assert!(quickstart_ja.contains("このプロジェクトを remotty に登録して"));
     assert!(quickstart_ja.contains("Codex CLI では"));
     assert!(quickstart_ja.contains("remotty config workspace upsert"));


### PR DESCRIPTION
## Summary
- allow `/remotty-sessions` to select Codex threads by title or ID
- preserve multi-word titles such as `Start workspace session`
- require shown IDs when titles are duplicated or conflict with ID prefixes
- update README, quickstarts, upgrade docs, and public-surface checks

Fixes #95

## Verification
- `git diff --check`
- `pwsh -NoProfile -File .\scripts\audit-public-surface.ps1`
- `pwsh -NoProfile -File .\scripts\audit-secret-surface.ps1`
- `cargo test`
- Opus public-doc review: PASS
- Codex implementation review: APPROVE