### PR TITLE
ci: update actions to node24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -42,7 +42,7 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
           path: target/${{ matrix.target }}/release/${{ matrix.binary }}
@@ -55,20 +55,20 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
 
       - name: Install PowerShell
         run: sudo apt-get update && sudo apt-get install -y powershell
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       - name: Run public release audits
@@ -92,7 +92,7 @@ jobs:
         run: ./scripts/generate-release-notes.ps1 -Version "${{ github.ref_name }}" -OutputPath "release/release-body.md"
 
       - name: Publish release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           body_path: release/release-body.md
           files: release/*

--- a/tests/public_surface.rs
+++ b/tests/public_surface.rs
@@ -138,7 +138,8 @@ fn npm_package_keeps_binary_install_contract() -> Result<()> {
     assert!(configure_skill.contains("PowerShell window"));
     assert!(start_skill.contains("remotty service start"));
     assert!(status_skill.contains("remotty telegram policy allowlist"));
-    assert!(release_workflow.contains("actions/setup-node@v4"));
+    assert!(release_workflow.contains("actions/setup-node@v6"));
+    assert!(release_workflow.contains("node-version: 24"));
     assert!(release_workflow.contains("npm pack --pack-destination release"));
     assert!(release_workflow.contains("cp release/remotty-*.tgz release/remotty.tgz"));
     assert!(release_workflow.contains("NPM_TOKEN: ${{ secrets.NPM_TOKEN }}"));


### PR DESCRIPTION
## Summary
- update GitHub-hosted workflow actions to Node.js 24 runtime versions
- run the release workflow npm publish step with Node.js 24

## Validation
- git diff --check
- searched for remaining Node.js 20 / old action references
- pre-commit checks passed